### PR TITLE
fix: invalidate Docker cache when dependencies change

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,8 +61,8 @@ jobs:
           push: true
           tags: ${{ steps.meta-backend.outputs.tags }}
           labels: ${{ steps.meta-backend.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=backend-${{ hashFiles('backend/requirements.txt') }}
+          cache-to: type=gha,mode=max,scope=backend-${{ hashFiles('backend/requirements.txt') }}
 
       - name: Build and push frontend
         uses: docker/build-push-action@v5
@@ -72,5 +72,5 @@ jobs:
           push: true
           tags: ${{ steps.meta-frontend.outputs.tags }}
           labels: ${{ steps.meta-frontend.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=frontend-${{ hashFiles('frontend/package-lock.json') }}
+          cache-to: type=gha,mode=max,scope=frontend-${{ hashFiles('frontend/package-lock.json') }}


### PR DESCRIPTION
## Summary
- Docker 빌드 캐시에 의존성 파일 해시 추가
- backend: requirements.txt 해시
- frontend: package-lock.json 해시

## Problem
GitHub Actions Docker 캐시가 오래된 레이어를 재사용하여 `ModuleNotFoundError: No module named 'slowapi'` 에러 발생

## Solution  
캐시 scope에 파일 해시를 추가하여 의존성 변경 시 자동으로 캐시 무효화

🤖 Generated with [Claude Code](https://claude.com/claude-code)