### PR TITLE
fix: remove get_embed_api_url from api exports

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -28,7 +28,6 @@ from .chat import router as chat_router
 # 의존성도 export
 from .dependencies import (
     get_db_config,
-    get_embed_api_url,
     get_retrieval_mode,
     get_retriever,
 )
@@ -73,6 +72,5 @@ __all__ = [
     # 의존성
     "get_retriever",
     "get_db_config",
-    "get_embed_api_url",
     "get_retrieval_mode",
 ]


### PR DESCRIPTION
## Summary
- `get_embed_api_url` import 제거 (dependencies.py에서 삭제됨)
- 스테이징 배포 시 ImportError 수정

## Error
```
ImportError: cannot import name 'get_embed_api_url' from 'app.api.dependencies'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)