### PR TITLE
fix: set VITE_API_BASE_URL for production build

### DIFF
--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -5,6 +5,9 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm ci
 COPY . .
+
+# Production에서는 상대 경로 사용 (nginx 프록시 통해 백엔드로 전달)
+ENV VITE_API_BASE_URL=""
 RUN npm run build
 
 # Production stage


### PR DESCRIPTION
## Summary
- Frontend 채팅이 프로덕션에서 작동 안 하는 문제 수정
- `VITE_API_BASE_URL`이 설정되지 않아 `localhost:8000`으로 요청하던 문제

## Fix
- Dockerfile.prod에서 `VITE_API_BASE_URL=""`로 설정
- 상대 경로로 요청하여 nginx 프록시 통해 백엔드로 전달

🤖 Generated with [Claude Code](https://claude.com/claude-code)