### PR TITLE
fix: add HTTP health check endpoint for CI/CD (#73)

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -8,6 +8,13 @@ server {
         root /var/www/certbot;
     }
 
+    # Health check (no redirect for CI/CD and monitoring)
+    location /health {
+        proxy_pass http://backend:8000/health;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+    }
+
     # Redirect to HTTPS (if certificate exists)
     location / {
         return 301 https://$host$request_uri;


### PR DESCRIPTION
## Summary
- HTTP 서버(포트 80)에 `/health` 엔드포인트 추가
- HTTPS 리다이렉트 없이 직접 백엔드로 프록시
- Deploy to Staging workflow의 External Health Check 실패 해결

## Changes
- `frontend/nginx.conf`: HTTP 서버 블록에 `/health` location 추가

## Test
- HTTP health check: `curl -sf http://15.165.215.141/health`
- HTTPS health check: `curl -sf https://ddoksori.duckdns.org/health` (기존 동작 유지)

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)