### PR TITLE
fix: Claude Code Review workflow 개선

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,12 +3,14 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    branches:
+      - main
+      - develop
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
 
 jobs:
   claude-review:
@@ -42,27 +44,28 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Please review this pull request and provide feedback on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
-            - Security concerns
-            - Test coverage
+            이 PR을 리뷰해주세요. 다음 항목을 균형있게 검토하세요:
 
-            **For documentation changes:**
-            - Distinguish between actual file deletions and content reorganization
-            - Before claiming something is "deleted", verify it doesn't exist in other files
-            - Cross-reference with actual workflow files in .github/workflows/ before commenting on CI/CD
-            - Check if referenced files/sections actually exist before flagging broken links
+            ## 버그 & 보안 (Critical)
+            - 잠재적 런타임 에러, null/undefined 처리
+            - OWASP Top 10 보안 취약점 (XSS, SQL Injection, etc.)
+            - 인증/인가 로직 검증
+            - 민감 정보 노출 여부 (.env, API 키 등)
 
-            **Important guidelines:**
-            - Use `gh pr diff ${{ github.event.pull_request.number }}` to see actual changes
-            - Use `ls` and `cat` to verify file existence before making claims
-            - Be precise about what was deleted vs moved vs reorganized
+            ## 품질 & 패턴 (Important)
+            - 코드 가독성, 네이밍 컨벤션
+            - CLAUDE.md에 정의된 프로젝트 스타일 준수
+            - 에러 핸들링 패턴
+            - 테스트 커버리지 (새 기능에 테스트가 있는지)
 
-            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+            ## 리뷰 가이드라인
+            - `gh pr diff ${{ github.event.pull_request.number }}`로 실제 변경사항 확인
+            - 파일 존재 여부는 `ls`, `cat`으로 검증
+            - 건설적이고 구체적인 피드백 제공
+            - 심각도 표시: 🔴 Critical, 🟡 Warning, 🟢 Suggestion
 
-            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
+            CLAUDE.md의 스타일 가이드를 참고하세요.
+            리뷰 완료 후 `gh pr comment`로 코멘트를 남기세요.
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options


### PR DESCRIPTION
## Summary
- Claude Code Review workflow이 스킵되는 문제 해결
- 브랜치 필터 및 문서 제외 설정 추가
- 균형 잡힌 코드 리뷰 프롬프트로 개선

## Changes
| 항목 | 변경 내용 |
|------|----------|
| 브랜치 필터 | `main`, `develop` 타겟 PR만 리뷰 |
| paths-ignore | `**/*.md`, `docs/**`, `LICENSE`, `.gitignore` 제외 |
| 프롬프트 | 버그/보안 + 품질/패턴 균형 잡힌 한글 리뷰 가이드 |
| 심각도 | 🔴 Critical, 🟡 Warning, 🟢 Suggestion |

## Test Plan
- [ ] develop → main PR 생성 시 리뷰 실행 확인
- [ ] 문서만 변경된 PR에서 스킵 확인
- [ ] 코드 변경 PR에서 리뷰 코멘트 확인

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)