### PR TITLE
chore: CI/CD에 docker-compose.prod.yml 동기화 추가 (#83)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -66,6 +66,17 @@ jobs:
             aws ecr get-login-password --region ap-northeast-2 | \
               docker login --username AWS --password-stdin $ECR_REGISTRY
 
+            # 설정 파일 동기화 (GitHub에서 최신 버전 다운로드)
+            echo "Syncing docker-compose.prod.yml from GitHub..."
+            curl -sf -o docker-compose.prod.yml.new \
+              https://raw.githubusercontent.com/SKN19-FINAL-5team/LLM/main/docker-compose.prod.yml
+            if [ -f docker-compose.prod.yml.new ]; then
+              mv docker-compose.prod.yml.new docker-compose.prod.yml
+              echo "docker-compose.prod.yml updated successfully"
+            else
+              echo "WARNING: Failed to download docker-compose.prod.yml, using existing file"
+            fi
+
             # 이미지 Pull
             echo "Pulling latest images..."
             docker compose -f docker-compose.prod.yml pull || {


### PR DESCRIPTION
## Summary
- 배포 시 GitHub에서 최신 `docker-compose.prod.yml` 다운로드
- 서버의 설정 파일이 Repository와 동기화되지 않아 발생하던 SSL 볼륨 마운트 누락 문제 해결

## Changes
- ECR 로그인 후, 이미지 Pull 전에 `curl`로 최신 설정 파일 다운로드
- 다운로드 실패 시 기존 파일 유지 (경고 출력)

## Test Plan
- [x] main 머지 후 Deploy to Staging 워크플로우 실행 확인
- [x] EC2에서 `docker-compose.prod.yml`에 SSL 볼륨 마운트 포함 여부 확인
- [x] HTTPS 접속 정상 동작 확인

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)