### PR TITLE
fix: Deploy 시 AWS Secrets Manager에서 REDIS_PASSWORD 가져오기 (#99)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -61,6 +61,28 @@ jobs:
             fi
             echo "ECR_REGISTRY: $ECR_REGISTRY"
 
+            # === AWS Secrets Manager에서 REDIS_PASSWORD 가져오기 ===
+            if [ -z "$REDIS_PASSWORD" ]; then
+              echo "Fetching REDIS_PASSWORD from AWS Secrets Manager..."
+              SECRET_JSON=$(aws secretsmanager get-secret-value \
+                --secret-id "ddoksori/${SECRETS_ENV:-staging}/infra" \
+                --region ap-northeast-2 \
+                --query 'SecretString' \
+                --output text 2>/dev/null || echo '{}')
+
+              REDIS_PASSWORD=$(echo "$SECRET_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('REDIS_PASSWORD',''))" 2>/dev/null)
+
+              if [ -z "$REDIS_PASSWORD" ]; then
+                echo "ERROR: REDIS_PASSWORD not found in Secrets Manager"
+                echo "Please add REDIS_PASSWORD to ddoksori/staging/infra secret"
+                exit 1
+              fi
+              export REDIS_PASSWORD
+              echo "REDIS_PASSWORD loaded from Secrets Manager"
+            else
+              echo "REDIS_PASSWORD already set from .env"
+            fi
+
             # ECR 로그인
             echo "Logging into ECR..."
             aws ecr get-login-password --region ap-northeast-2 | \


### PR DESCRIPTION
## Summary
PR #96 (SEC-40) Redis 인증 추가 후 Deploy to Staging 워크플로우 실패 수정

### 문제
```
Container ddoksori-redis-1  Error
dependency failed to start: container ddoksori-redis-1 is unhealthy
```

### 원인
- `docker-compose.prod.yml`에서 `${REDIS_PASSWORD}` 사용
- Docker Compose 시작 시점에 환경변수 필요
- 현재 `inject_aws_secrets()`는 백엔드 컨테이너 내부에서만 동작
- EC2 `.env`에 `REDIS_PASSWORD` 미설정

### 해결
- deploy-staging.yml에 AWS Secrets Manager 조회 로직 추가
- `ddoksori/${SECRETS_ENV:-staging}/infra`에서 `REDIS_PASSWORD` 가져옴
- `.env`에 이미 설정된 경우 Secrets Manager 조회 생략

## Test Plan
- [ ] Secrets Manager에 `REDIS_PASSWORD` 설정 확인 ✅ (사용자 완료)
- [ ] develop merge 후 main merge 시 Deploy 성공 확인
- [ ] Redis 컨테이너 healthy 상태 확인
- [ ] `/health` 엔드포인트 응답 확인

Refs #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)