### PR TITLE
fix: P1/P2 issues from QA test

### DIFF
--- a/backend/app/agents/answer_generation/agent.py
+++ b/backend/app/agents/answer_generation/agent.py
@@ -26,6 +26,7 @@ from typing import Any, Dict, List
 from langchain_core.messages import AIMessage
 
 from ...domain import AGENCY_INFO
+from ..followup.generator import FollowupQuestionGenerator
 from ..retrieval.sufficiency import RetrievalSufficiencyChecker
 from .cache import get_answer_cache
 from .context_builder import ContextBuilder
@@ -954,6 +955,16 @@ async def generation_node_v2(state: Dict, config: Any = None) -> Dict:
     cited_cases = _extract_cited_cases(retrieval)
     has_evidence = model_used not in ("rule_based", "safe_fallback")
 
+    # Phase 6: Generate followup questions
+    query_analysis = state.get("query_analysis", {})
+    followup_generator = FollowupQuestionGenerator()
+    followup_result = followup_generator.generate_questions(
+        query_analysis=query_analysis,
+        retrieval=retrieval,
+        answer=draft_answer,
+    )
+    followup_questions = followup_result.get("followup_questions", [])
+
     if not retry_context:
         cache = get_answer_cache()
         cache.set(
@@ -974,7 +985,7 @@ async def generation_node_v2(state: Dict, config: Any = None) -> Dict:
         "cited_cases": cited_cases,
         "has_sufficient_evidence": has_evidence,
         "retrieval_confidence": retrieval_confidence,
-        "followup_questions": [],
+        "followup_questions": followup_questions,
         "response_depth": "full",
         "available_details": None,
         "generation_time_ms": (time.time() - start_time) * 1000,

--- a/backend/app/agents/retrieval/tools/specialized_retrievers.py
+++ b/backend/app/agents/retrieval/tools/specialized_retrievers.py
@@ -269,6 +269,11 @@ class CriteriaRetriever:
 
         results: List[SimilarChunkResult] = []
         for row in rows:
+            if not isinstance(row, dict):
+                logger.warning(
+                    "[CriteriaRetriever] Skipping non-dict row: %s", type(row)
+                )
+                continue
             metadata = row.get("metadata")
             if isinstance(metadata, str):
                 try:
@@ -445,6 +450,12 @@ class CriteriaRetriever:
 
             results: List[SimilarChunkResult] = []
             for row in cur.fetchall():
+                if not isinstance(row, (tuple, list)):
+                    logger.warning(
+                        "[CriteriaRetriever.criteria_search] Skipping non-tuple row: %s",
+                        type(row),
+                    )
+                    continue
                 metadata = row[14]
                 if isinstance(metadata, str):
                     try:

--- a/backend/app/supervisor/nodes/clarify.py
+++ b/backend/app/supervisor/nodes/clarify.py
@@ -290,6 +290,25 @@ def ask_clarification_node(state: ChatState) -> Dict[str, Any]:
     query_analysis = state.get("query_analysis") or {}
     query_type = query_analysis.get("query_type")
 
+    # 매우 짧은 쿼리 (1-4자)는 상세 정보 요청
+    user_query = state.get("user_query", "")
+    if len(user_query.strip()) <= 4 and query_type in ("dispute", "criteria"):
+        short_query_questions = [
+            "어떤 제품이나 서비스와 관련된 문의인가요?",
+            "구체적으로 어떤 상황에서 문제가 발생했나요?",
+            "현재 원하시는 해결 방법이 있으신가요? (예: 환불, 교환, 수리 등)",
+        ]
+        response = _build_clarification_response(short_query_questions)
+        logger.info(
+            f"[Clarify] Very short dispute/criteria query detected: '{user_query}' (length: {len(user_query.strip())})"
+        )
+        return {
+            "final_answer": response,
+            "clarifying_questions": short_query_questions,
+            "awaiting_user_choice": True,
+            "messages": [AIMessage(content=response)],
+        }
+
     if query_type == "ambiguous":
         user_query = state.get("user_query", "")
         if len(user_query.strip()) <= 5:


### PR DESCRIPTION
## Summary
QA 테스트에서 발견된 P1/P2 이슈 수정

### P1 (High)
- **CriteriaRetriever NoneType 에러**: `row` 타입 검증 추가 (`specialized_retrievers.py`)

### P2 (Medium)
- **짧은 쿼리 clarifying_questions 미제공**: 4자 이하 분쟁 쿼리에 명확화 질문 제공 (`clarify.py`)
- **followup_questions 빈 배열**: `FollowupQuestionGenerator` 통합 (`agent.py`)

## Test plan
- [x] Supervisor 단위 테스트 통과 (239 passed)
- [x] 시스템 아키텍처 테스트 통과 (23 passed)
- [ ] 프로덕션 API 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)