### PR TITLE
fix: metadata empty dict → None 버그 수정 (P1 진짜 원인)

### DIFF
--- a/backend/app/agents/retrieval/tools/specialized_retrievers.py
+++ b/backend/app/agents/retrieval/tools/specialized_retrievers.py
@@ -148,7 +148,7 @@ class LawRetriever:
                     source_file=row.get("source_file"),
                     printed_page=row.get("printed_page"),
                     source_year=row.get("source_year"),
-                    metadata=metadata or None,
+                    metadata=metadata,
                     vector_similarity=float(row.get("vector_similarity", 0.0)),
                     rrf_score=float(row.get("rrf_score", 0.0)),
                 )
@@ -312,7 +312,7 @@ class CriteriaRetriever:
                     source_file=row.get("source_file"),
                     printed_page=row.get("printed_page"),
                     source_year=row.get("source_year"),
-                    metadata=metadata or None,
+                    metadata=metadata,
                     vector_similarity=float(row.get("vector_similarity", 0.0)),
                     rrf_score=float(row.get("rrf_score", 0.0)),
                 )
@@ -478,7 +478,7 @@ class CriteriaRetriever:
                         source_file=row[11],
                         printed_page=row[12],
                         source_year=row[13],
-                        metadata=metadata or None,
+                        metadata=metadata,
                         vector_similarity=float(row[5] or 0.0),
                         rrf_score=float(row[3] or 0.0),
                     )


### PR DESCRIPTION
## Summary
`retrieval_law`, `retrieval_criteria` 에이전트 100% 실패 원인 수정

## Problem
```python
metadata=metadata or None  # 빈 dict {}를 None으로 변환
```
- `{}` (빈 dict)는 Python에서 falsy로 평가됨
- `or None`으로 인해 `{}` → `None` 변환
- 이후 `metadata.get()` 호출 시 `'NoneType' object has no attribute 'get'` 에러

## Fix
3개 위치에서 패턴 수정:
- `LawRetriever.hybrid_search` (line 148)
- `CriteriaRetriever.hybrid_search` (line 312)  
- `CriteriaRetriever.criteria_search` (line 478)

## QA Report Reference
`.omc/reports/qa-test-report-2026-02-04.md` - P1 (High) 이슈

🤖 Generated with [Claude Code](https://claude.com/claude-code)