### PR TITLE
fix: P2 이슈 수정 - clarify 규칙 + followup 생성

### DIFF
--- a/backend/app/agents/answer_generation/agent.py
+++ b/backend/app/agents/answer_generation/agent.py
@@ -514,13 +514,23 @@ def _followup_detail_response(state: Dict, config=None) -> Dict:
     cited_cases = _extract_cited_cases(filtered_retrieval)
     has_evidence = model_used not in ("rule_based", "safe_fallback")
 
+    # Generate followup questions (캐시 응답에서도 생성)
+    query_analysis = state.get("query_analysis", {})
+    followup_generator = FollowupQuestionGenerator()
+    followup_result = followup_generator.generate_questions(
+        query_analysis=query_analysis,
+        retrieval=filtered_retrieval,
+        answer=draft_answer,
+    )
+    followup_questions = followup_result.get("followup_questions", [])
+
     return {
         "draft_answer": draft_answer,
         "claim_evidence_map": claim_evidence_map,
         "cited_cases": cited_cases,
         "has_sufficient_evidence": has_evidence,
         "retrieval_confidence": 0.8,  # 캐시 사용이므로 고정값
-        "followup_questions": [],
+        "followup_questions": followup_questions,
         "response_depth": "detail",
         "available_details": None,
         "retrieval": filtered_retrieval,  # retrieval state도 업데이트

--- a/backend/app/supervisor/nodes/supervisor.py
+++ b/backend/app/supervisor/nodes/supervisor.py
@@ -488,6 +488,7 @@ class SupervisorNode:
 {self._format_agents()}
 
 ## 중요 규칙 (반드시 준수)
+0. 사용자 질문이 너무 짧거나(5자 이하) 모호하면 → clarify 먼저 (예: "환불", "교환", "어떻게")
 1. "질의 분석"이 없으면 → query_analyst 호출 필수
 2. "검색 결과"가 없으면 → retrieval_team 호출 필수
 3. "답변 초안"이 없으면 → answer_drafter 호출 필수


### PR DESCRIPTION
## Summary
QA 테스트 P2 이슈 2개 수정

## P2-1: 모호한 질문에 clarifying_questions 미제공
**문제**: Supervisor가 `action: "clarify"`를 선택하지 않음 (규칙 없음)

**수정**: Supervisor 프롬프트에 규칙 0 추가
```
0. 사용자 질문이 너무 짧거나(5자 이하) 모호하면 → clarify 먼저
   예: "환불", "교환", "어떻게"
```

## P2-2: followup_questions API 필드 빈 배열
**문제**: 캐시 응답 경로에서 `followup_questions: []` 하드코딩

**수정**: 캐시 응답에서도 FollowupQuestionGenerator 호출
```python
# Before
"followup_questions": [],

# After
followup_generator = FollowupQuestionGenerator()
followup_result = followup_generator.generate_questions(...)
"followup_questions": followup_result.get("followup_questions", []),
```

## QA Report Reference
`.omc/reports/qa-test-report-2026-02-04.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)