### PR TITLE
fix: add defensive null check for agent.process() result

### DIFF
--- a/backend/app/supervisor/graph_mas.py
+++ b/backend/app/supervisor/graph_mas.py
@@ -211,14 +211,29 @@ def _create_retrieval_agent_node(agent_type: str) -> Callable:
         }
 
         try:
+            if agent is None:
+                raise ValueError(f"Agent '{agent_type}' not found in agent_map")
+
             result = await agent.process(request)
             search_time_ms = (time.time() - start_time) * 1000
 
+            # 방어적 체크: result가 None인 경우 처리
+            if result is None:
+                logger.warning(
+                    f"[RetrievalAgent_v2:{agent_type}] agent.process() returned None"
+                )
+                result = {
+                    "status": "failure",
+                    "message": "Agent returned None",
+                    "result": None,
+                }
+
+            result_data = result.get("result") or {}
             individual_result = {
                 "source": agent_type,
-                "documents": result.get("result", {}).get("results", []),
-                "max_similarity": result.get("result", {}).get("max_similarity", 0.0),
-                "avg_similarity": result.get("result", {}).get("avg_similarity", 0.0),
+                "documents": result_data.get("results", []),
+                "max_similarity": result_data.get("max_similarity", 0.0),
+                "avg_similarity": result_data.get("avg_similarity", 0.0),
                 "search_time_ms": search_time_ms,
             }
 


### PR DESCRIPTION
## Summary
Retrieval agent가 None을 반환할 때 NoneType 에러 방지

## Changes
- agent.process() 결과에 대한 null 체크 추가
- result가 None인 경우 failure response로 변환
- result_data 추출 시 or {} 패턴으로 방어적 처리

## Root Cause (아직 조사 중)
- law_retrieval_agent와 criteria_retrieval_agent가 가끔 None을 반환
- BaseRetrievalAgent.process()의 모든 경로가 dict를 반환해야 함
- 추후 근본 원인 파악 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)