### PR TITLE
fix: load JWT/OAuth secrets from AWS Secrets Manager (#123)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -61,20 +61,28 @@ jobs:
             fi
             echo "ECR_REGISTRY: $ECR_REGISTRY"
 
-            # === AWS Secrets Manager에서 REDIS_PASSWORD 가져오기 ===
+            # === AWS Secrets Manager에서 환경변수 가져오기 ===
+            echo "Fetching secrets from AWS Secrets Manager..."
+
+            # infra secrets (REDIS_PASSWORD)
+            INFRA_SECRET=$(aws secretsmanager get-secret-value \
+              --secret-id "ddoksori/${SECRETS_ENV:-staging}/infra" \
+              --region ap-northeast-2 \
+              --query 'SecretString' \
+              --output text 2>/dev/null || echo '{}')
+
+            # app secrets (JWT, OAuth)
+            APP_SECRET=$(aws secretsmanager get-secret-value \
+              --secret-id "ddoksori/${SECRETS_ENV:-staging}/app" \
+              --region ap-northeast-2 \
+              --query 'SecretString' \
+              --output text 2>/dev/null || echo '{}')
+
+            # REDIS_PASSWORD (from infra or .env)
             if [ -z "$REDIS_PASSWORD" ]; then
-              echo "Fetching REDIS_PASSWORD from AWS Secrets Manager..."
-              SECRET_JSON=$(aws secretsmanager get-secret-value \
-                --secret-id "ddoksori/${SECRETS_ENV:-staging}/infra" \
-                --region ap-northeast-2 \
-                --query 'SecretString' \
-                --output text 2>/dev/null || echo '{}')
-
-              REDIS_PASSWORD=$(echo "$SECRET_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('REDIS_PASSWORD',''))" 2>/dev/null)
-
+              REDIS_PASSWORD=$(echo "$INFRA_SECRET" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('REDIS_PASSWORD',''))" 2>/dev/null)
               if [ -z "$REDIS_PASSWORD" ]; then
                 echo "ERROR: REDIS_PASSWORD not found in Secrets Manager"
-                echo "Please add REDIS_PASSWORD to ddoksori/staging/infra secret"
                 exit 1
               fi
               export REDIS_PASSWORD
@@ -82,6 +90,35 @@ jobs:
             else
               echo "REDIS_PASSWORD already set from .env"
             fi
+
+            # JWT_SECRET_KEY (필수 - SEC-01)
+            if [ -z "$JWT_SECRET_KEY" ]; then
+              JWT_SECRET_KEY=$(echo "$APP_SECRET" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('JWT_SECRET_KEY',''))" 2>/dev/null)
+              if [ -z "$JWT_SECRET_KEY" ]; then
+                echo "ERROR: JWT_SECRET_KEY not found in Secrets Manager"
+                echo "Please add JWT_SECRET_KEY to ddoksori/staging/app secret"
+                exit 1
+              fi
+              export JWT_SECRET_KEY
+              echo "JWT_SECRET_KEY loaded from Secrets Manager"
+            else
+              echo "JWT_SECRET_KEY already set from .env"
+            fi
+
+            # OAuth secrets (optional - 경고만)
+            for VAR in GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET NAVER_CLIENT_ID NAVER_CLIENT_SECRET; do
+              if [ -z "$(eval echo \$$VAR)" ]; then
+                VALUE=$(echo "$APP_SECRET" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('$VAR',''))" 2>/dev/null)
+                if [ -n "$VALUE" ]; then
+                  export $VAR="$VALUE"
+                  echo "$VAR loaded from Secrets Manager"
+                else
+                  echo "WARNING: $VAR not found (OAuth login may not work)"
+                fi
+              else
+                echo "$VAR already set from .env"
+              fi
+            done
 
             # ECR 로그인
             echo "Logging into ECR..."


### PR DESCRIPTION
## Summary
Staging 배포 실패 수정 - SEC-01 환경변수 누락 해결

## Problem
PR #121 (SEC-01 보안 설정 검증 추가) 이후 staging 배포 실패:
```
Container ddoksori-backend-1 is unhealthy
[SEC-01] JWT_SECRET_KEY가 기본값이거나 미설정됨 - 프로덕션에서 변경 필수!
```

EC2 `.env` 파일에 JWT_SECRET_KEY가 없어서 컨테이너 시작 실패

## Solution
deploy-staging.yml에서 AWS Secrets Manager로부터 환경변수 로드:
- `ddoksori/staging/infra`: REDIS_PASSWORD
- `ddoksori/staging/app`: JWT_SECRET_KEY, OAuth credentials

## Changes
- JWT_SECRET_KEY: Secrets Manager에서 로드 (필수, 없으면 배포 실패)
- OAuth secrets: Secrets Manager에서 로드 (선택, 없으면 경고만)
- REDIS_PASSWORD: 기존 infra secret에서 로드 유지

## Test Plan
- [ ] CI 5개 체크 통과 (backend-test, backend-lint, frontend-build, frontend-lint, claude-review)
- [ ] develop merge 후 staging 배포 검증 (/health 200 OK)

Refs #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)