### PR TITLE
fix: 분쟁 상담 추가질문 버블 클릭 시 자동 전송 (#128)

### DIFF
--- a/frontend/src/features/chat/ChatPage.tsx
+++ b/frontend/src/features/chat/ChatPage.tsx
@@ -450,7 +450,7 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
   };
 
   // 분쟁 상담 메시지 전송 공통 함수
-  const sendDisputeMessage = async (messageContent: string) => {
+  const sendDisputeMessage = useCallback(async (messageContent: string) => {
     if (!messageContent.trim() || disputeStreamingState.isStreaming) return;
 
     // 세션 ID를 스트림 시작 전에 확정
@@ -535,7 +535,17 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
         )
       );
     }
-  };
+  }, [
+    disputeStreamingState.isStreaming,
+    sessionId,
+    setSessionId,
+    setStoreSessionId,
+    setStoreChatType,
+    onSessionCreate,
+    setDisputeMessages,
+    startDisputeStream,
+    setBackendSessionId,
+  ]);
 
   // 분쟁 상담 메시지 전송 핸들러 (PR-7: SSE Streaming)
   const handleDisputeSend = async () => {


### PR DESCRIPTION
## Summary
- 온보딩 완료 후 추가질문 버블 클릭 시 자동 전송되도록 개선
- 기존에는 입력창에만 복사되어 별도로 Enter 필요했음

## Changes
- `sendDisputeMessage` 공통 함수 추출 (중복 코드 제거)
- `handleDisputeSend`가 공통 함수 사용하도록 리팩토링
- `handleDisputeFollowupSelect`에서 공통 함수 호출하여 자동 전송

## Technical Details
- 기존 `useStreamingChat` 훅의 `convertDisputeFormToOnboarding()` 활용
- `disputeFormData` Zustand 스토어에서 자동으로 onboarding 컨텍스트 포함
- `isStreaming` 체크로 중복 전송 방지

## Test
- [ ] 온보딩 후 추가질문 버블 클릭 시 자동 전송 확인
- [ ] 응답에서 온보딩 컨텍스트 인식 확인
- [ ] 일반 입력창 메시지 전송 정상 동작 확인

Refs #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)