### PR TITLE
fix: 분쟁 상담 추가질문 자동전송 (#128)

### DIFF
--- a/frontend/src/features/chat/ChatPage.tsx
+++ b/frontend/src/features/chat/ChatPage.tsx
@@ -449,9 +449,9 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
     }
   };
 
-  // 분쟁 상담 메시지 전송 핸들러 (PR-7: SSE Streaming)
-  const handleDisputeSend = async () => {
-    if (!disputeInputValue.trim() || disputeStreamingState.isStreaming) return;
+  // 분쟁 상담 메시지 전송 공통 함수
+  const sendDisputeMessage = useCallback(async (messageContent: string) => {
+    if (!messageContent.trim() || disputeStreamingState.isStreaming) return;
 
     // 세션 ID를 스트림 시작 전에 확정
     if (!sessionId) {
@@ -461,9 +461,6 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
       setStoreChatType('dispute');
       if (onSessionCreate) onSessionCreate(newId);
     }
-
-    const messageContent = disputeInputValue;
-    setDisputeInputValue('');
 
     const userMsgId = ++messageIdCounterRef.current;
     const aiPlaceholderId = ++messageIdCounterRef.current;
@@ -538,6 +535,26 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
         )
       );
     }
+  }, [
+    disputeStreamingState.isStreaming,
+    sessionId,
+    setSessionId,
+    setStoreSessionId,
+    setStoreChatType,
+    onSessionCreate,
+    setDisputeMessages,
+    startDisputeStream,
+    setBackendSessionId,
+  ]);
+
+  // 분쟁 상담 메시지 전송 핸들러 (PR-7: SSE Streaming)
+  const handleDisputeSend = async () => {
+    if (!disputeInputValue.trim() || disputeStreamingState.isStreaming) return;
+
+    const messageContent = disputeInputValue;
+    setDisputeInputValue('');
+
+    await sendDisputeMessage(messageContent);
   };
 
   // 일반 상담 메시지 전송 핸들러 (PR-7: SSE Streaming)
@@ -634,9 +651,9 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
   };
 
   // 추가 질문 클릭 핸들러
-  const handleDisputeFollowupSelect = useCallback((question: string) => {
-    setDisputeInputValue(question);
-  }, []);
+  const handleDisputeFollowupSelect = useCallback(async (question: string) => {
+    await sendDisputeMessage(question);
+  }, [sendDisputeMessage]);
 
   const handleGeneralFollowupSelect = useCallback((question: string) => {
     setGeneralInputValue(question);


### PR DESCRIPTION
## Summary
- 분쟁 상담 채팅에서 추가질문 버블 클릭 시 자동 전송되도록 수정
- `sendDisputeMessage` 공통 함수 추출 및 `useCallback`으로 memoization

## Changes
- `handleDisputeFollowupSelect`: 입력창 채우기 → 즉시 메시지 전송
- `sendDisputeMessage`: 메시지 전송 로직 공통화 (세션 생성, UI 업데이트, API 호출)
- React hooks 안정성: `useCallback`으로 stale closure 방지

## Test Plan
- [x] 분쟁 상담 추가질문 버블 클릭 시 즉시 전송 확인
- [x] 기존 입력창 직접 전송 기능 정상 동작
- [x] Frontend build 성공
- [x] CI 5개 체크 통과

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)