### PR TITLE
fix: OAuth 로그인 400 오류 - 크리덴셜 미설정 시 방어 코드 추가 (#152)

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -38,6 +38,7 @@ from fastapi.responses import RedirectResponse
 
 from app.auth.dependencies import decode_access_token, get_current_user
 from app.auth.models import User
+from app.auth.oauth import OAuthConfigError
 from app.auth.service import AuthService
 from app.auth.user_db import UserDB
 from app.common.config import get_config
@@ -172,8 +173,15 @@ async def google_login(request: Request):
     Returns:
         RedirectResponse: Google 인증 URL로 리다이렉트
     """
-    auth_service = AuthService()
-    auth_url, state = auth_service.get_google_auth_url()
+    try:
+        auth_service = AuthService()
+        auth_url, state = auth_service.get_google_auth_url()
+    except OAuthConfigError as e:
+        logger.error(f"[Auth] Google OAuth 미설정: {e}")
+        error_url = (
+            f"{get_config().auth.frontend_url}/auth/callback#error=oauth_not_configured"
+        )
+        return RedirectResponse(error_url)
 
     # State 저장 (CSRF 방지)
     _store_state(state)
@@ -230,6 +238,13 @@ async def google_callback(
         logger.info(f"[Auth] Google 콜백 성공: user_id={auth_response.user.user_id}")
         return RedirectResponse(redirect_url)
 
+    except OAuthConfigError as e:
+        logger.error(f"[Auth] Google OAuth 미설정 (콜백): {e}")
+        error_url = (
+            f"{get_config().auth.frontend_url}/auth/callback#error=oauth_not_configured"
+        )
+        return RedirectResponse(error_url)
+
     except Exception as e:
         logger.error(f"[Auth] Google 콜백 실패: {e}", exc_info=True)
         # [SEC-03] 보안: 원시 예외 대신 일반 에러 메시지 사용
@@ -253,8 +268,15 @@ async def naver_login(request: Request):
     Returns:
         RedirectResponse: Naver 인증 URL로 리다이렉트
     """
-    auth_service = AuthService()
-    auth_url, state = auth_service.get_naver_auth_url()
+    try:
+        auth_service = AuthService()
+        auth_url, state = auth_service.get_naver_auth_url()
+    except OAuthConfigError as e:
+        logger.error(f"[Auth] Naver OAuth 미설정: {e}")
+        error_url = (
+            f"{get_config().auth.frontend_url}/auth/callback#error=oauth_not_configured"
+        )
+        return RedirectResponse(error_url)
 
     # State 저장 (CSRF 방지)
     _store_state(state)
@@ -310,6 +332,13 @@ async def naver_callback(
 
         logger.info(f"[Auth] Naver 콜백 성공: user_id={auth_response.user.user_id}")
         return RedirectResponse(redirect_url)
+
+    except OAuthConfigError as e:
+        logger.error(f"[Auth] Naver OAuth 미설정 (콜백): {e}")
+        error_url = (
+            f"{get_config().auth.frontend_url}/auth/callback#error=oauth_not_configured"
+        )
+        return RedirectResponse(error_url)
 
     except Exception as e:
         logger.error(f"[Auth] Naver 콜백 실패: {e}", exc_info=True)

--- a/backend/app/auth/oauth.py
+++ b/backend/app/auth/oauth.py
@@ -44,6 +44,12 @@ from app.common.config import AuthConfig
 logger = logging.getLogger(__name__)
 
 
+class OAuthConfigError(Exception):
+    """OAuth 크리덴셜이 설정되지 않았을 때 발생하는 예외"""
+
+    pass
+
+
 class OAuthProvider(ABC):
     """
     OAuth 2.0 제공자 추상 클래스.
@@ -146,7 +152,16 @@ class GoogleOAuth(OAuthProvider):
 
         Returns:
             (authorization_url, state)
+
+        Raises:
+            OAuthConfigError: Google OAuth 크리덴셜이 미설정
         """
+        if not self.auth_config.is_google_oauth_configured:
+            raise OAuthConfigError(
+                "Google OAuth 크리덴셜(GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET)이 "
+                "설정되지 않았습니다. 환경변수 또는 AWS Secrets Manager를 확인하세요."
+            )
+
         if state is None:
             state = secrets.token_urlsafe(32)
 
@@ -179,8 +194,15 @@ class GoogleOAuth(OAuthProvider):
             Token 정보 딕셔너리
 
         Raises:
+            OAuthConfigError: Google OAuth 크리덴셜이 미설정
             httpx.HTTPError: API 호출 실패
         """
+        if not self.auth_config.is_google_oauth_configured:
+            raise OAuthConfigError(
+                "Google OAuth 크리덴셜(GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET)이 "
+                "설정되지 않았습니다. 환경변수 또는 AWS Secrets Manager를 확인하세요."
+            )
+
         redirect_uri = f"{self.auth_config.backend_url}/auth/google/callback"
 
         data = {
@@ -256,7 +278,16 @@ class NaverOAuth(OAuthProvider):
 
         Returns:
             (authorization_url, state)
+
+        Raises:
+            OAuthConfigError: Naver OAuth 크리덴셜이 미설정
         """
+        if not self.auth_config.is_naver_oauth_configured:
+            raise OAuthConfigError(
+                "Naver OAuth 크리덴셜(NAVER_CLIENT_ID, NAVER_CLIENT_SECRET)이 "
+                "설정되지 않았습니다. 환경변수 또는 AWS Secrets Manager를 확인하세요."
+            )
+
         if state is None:
             state = secrets.token_urlsafe(32)
 
@@ -286,8 +317,15 @@ class NaverOAuth(OAuthProvider):
             Token 정보 딕셔너리
 
         Raises:
+            OAuthConfigError: Naver OAuth 크리덴셜이 미설정
             httpx.HTTPError: API 호출 실패
         """
+        if not self.auth_config.is_naver_oauth_configured:
+            raise OAuthConfigError(
+                "Naver OAuth 크리덴셜(NAVER_CLIENT_ID, NAVER_CLIENT_SECRET)이 "
+                "설정되지 않았습니다. 환경변수 또는 AWS Secrets Manager를 확인하세요."
+            )
+
         # Note: Naver doesn't require redirect_uri in token exchange
         # but log for consistency
         redirect_uri = f"{self.auth_config.backend_url}/auth/naver/callback"

--- a/backend/app/common/config.py
+++ b/backend/app/common/config.py
@@ -546,6 +546,16 @@ class AuthConfig(BaseSettings):
         description="Frontend URL",
     )
 
+    @property
+    def is_google_oauth_configured(self) -> bool:
+        """Google OAuth 크리덴셜이 모두 설정되어 있는지 확인"""
+        return bool(self.google_client_id) and bool(self.google_client_secret)
+
+    @property
+    def is_naver_oauth_configured(self) -> bool:
+        """Naver OAuth 크리덴셜이 모두 설정되어 있는지 확인"""
+        return bool(self.naver_client_id) and bool(self.naver_client_secret)
+
 
 # ============================================================
 # 대화 메모리 설정

--- a/backend/app/common/secrets.py
+++ b/backend/app/common/secrets.py
@@ -33,6 +33,8 @@ SECRET_CATEGORIES = [
     "infra",
 ]
 
+CRITICAL_CATEGORIES = {"oauth/google", "oauth/naver", "security"}
+
 _injected = False
 
 
@@ -86,9 +88,22 @@ def inject_aws_secrets() -> int:
             # ResourceNotFoundException 포함 모든 예외 처리
             error_type = type(e).__name__
             if "ResourceNotFoundException" in error_type:
-                logger.warning("Secret not found: %s", secret_name)
+                if category in CRITICAL_CATEGORIES:
+                    logger.error("CRITICAL: Secret not found: %s", secret_name)
+                else:
+                    logger.warning("Secret not found: %s", secret_name)
             else:
                 logger.error("Failed to load secret %s: %s", secret_name, e)
+
+    oauth_keys = [
+        "GOOGLE_CLIENT_ID",
+        "GOOGLE_CLIENT_SECRET",
+        "NAVER_CLIENT_ID",
+        "NAVER_CLIENT_SECRET",
+    ]
+    missing = [k for k in oauth_keys if not os.environ.get(k)]
+    if missing:
+        logger.error("OAuth 환경변수 누락: %s - 소셜 로그인 불가", ", ".join(missing))
 
     logger.info(
         "Injected %d secrets from AWS Secrets Manager (%s)", injected, environment

--- a/backend/scripts/testing/auth/test_oauth_config_validation.py
+++ b/backend/scripts/testing/auth/test_oauth_config_validation.py
@@ -1,0 +1,201 @@
+"""
+Unit tests for OAuth config validation
+
+작성일: 2026-02-06
+설명: OAuth 크리덴셜 미설정 시 방어 코드 검증 (Unit - 모킹 사용)
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.auth.oauth import GoogleOAuth, OAuthConfigError
+from app.common.config import AuthConfig
+
+
+def _make_auth_config(**overrides) -> AuthConfig:
+    """테스트용 AuthConfig를 생성합니다."""
+    defaults = {
+        "JWT_SECRET_KEY": "test_secret",
+        "BACKEND_URL": "http://localhost:8000",
+        "FRONTEND_URL": "http://localhost:5173",
+    }
+    defaults.update(overrides)
+    return AuthConfig(**defaults)
+
+
+# ============================================================
+# AuthConfig 프로퍼티 테스트
+# ============================================================
+
+
+@pytest.mark.unit
+def test_google_oauth_configured_true():
+    """Google client_id, secret 모두 있을 때 True"""
+    config = _make_auth_config(
+        GOOGLE_CLIENT_ID="test-id",
+        GOOGLE_CLIENT_SECRET="test-secret",
+    )
+    assert config.is_google_oauth_configured is True
+
+
+@pytest.mark.unit
+def test_google_oauth_configured_false_missing_id():
+    """Google client_id None → False"""
+    config = _make_auth_config(
+        GOOGLE_CLIENT_SECRET="test-secret",
+    )
+    assert config.is_google_oauth_configured is False
+
+
+@pytest.mark.unit
+def test_google_oauth_configured_false_empty_string():
+    """Google client_id 빈 문자열 → False"""
+    config = _make_auth_config(
+        GOOGLE_CLIENT_ID="",
+        GOOGLE_CLIENT_SECRET="test-secret",
+    )
+    assert config.is_google_oauth_configured is False
+
+
+@pytest.mark.unit
+def test_google_oauth_configured_false_missing_secret():
+    """Google secret만 None → False"""
+    config = _make_auth_config(
+        GOOGLE_CLIENT_ID="test-id",
+    )
+    assert config.is_google_oauth_configured is False
+
+
+@pytest.mark.unit
+def test_naver_oauth_configured():
+    """Naver 크리덴셜 검증 - 모두 있으면 True, 없으면 False"""
+    config_with = _make_auth_config(
+        NAVER_CLIENT_ID="test-id",
+        NAVER_CLIENT_SECRET="test-secret",
+    )
+    assert config_with.is_naver_oauth_configured is True
+
+    config_without = _make_auth_config()
+    assert config_without.is_naver_oauth_configured is False
+
+
+# ============================================================
+# OAuthConfigError 테스트
+# ============================================================
+
+
+@pytest.mark.unit
+def test_get_authorization_url_raises_config_error():
+    """Google client_id None → OAuthConfigError 발생"""
+    config = _make_auth_config()  # 크리덴셜 없음
+    google = GoogleOAuth(config)
+
+    with pytest.raises(OAuthConfigError, match="Google OAuth"):
+        google.get_authorization_url()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_exchange_code_raises_config_error():
+    """토큰 교환 시 크리덴셜 없으면 OAuthConfigError"""
+    config = _make_auth_config()
+    google = GoogleOAuth(config)
+
+    with pytest.raises(OAuthConfigError, match="Google OAuth"):
+        await google.exchange_code_for_token("fake_code")
+
+
+@pytest.mark.unit
+def test_get_authorization_url_works_with_credentials():
+    """정상 크리덴셜 → URL 생성 성공"""
+    config = _make_auth_config(
+        GOOGLE_CLIENT_ID="test-id",
+        GOOGLE_CLIENT_SECRET="test-secret",
+    )
+    google = GoogleOAuth(config)
+
+    url, state = google.get_authorization_url()
+    assert "accounts.google.com" in url
+    assert "test-id" in url
+    assert len(state) > 0
+
+
+# ============================================================
+# 라우트 에러 리다이렉트 테스트
+# ============================================================
+
+
+@pytest.mark.unit
+def test_auth_route_redirects_on_config_error():
+    """라우트에서 OAuthConfigError → oauth_not_configured 리다이렉트"""
+    from fastapi.testclient import TestClient
+
+    from app.api.auth import router
+
+    app = __import__("fastapi", fromlist=["FastAPI"]).FastAPI()
+    app.include_router(router)
+
+    with (
+        patch("app.api.auth.AuthService") as mock_service_cls,
+        patch("app.api.auth.limiter") as mock_limiter,
+    ):
+        # limiter를 무력화
+        mock_limiter.limit.return_value = lambda f: f
+        mock_service = mock_service_cls.return_value
+        mock_service.get_google_auth_url.side_effect = OAuthConfigError("test")
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.get("/auth/google", follow_redirects=False)
+
+        assert response.status_code == 307
+        assert "oauth_not_configured" in response.headers.get("location", "")
+
+
+@pytest.mark.unit
+def test_callback_route_config_error_vs_general_error():
+    """콜백에서 OAuthConfigError와 일반 Exception 구분"""
+    from fastapi.testclient import TestClient
+
+    from app.api.auth import router
+
+    app = __import__("fastapi", fromlist=["FastAPI"]).FastAPI()
+    app.include_router(router)
+
+    # OAuthConfigError → oauth_not_configured
+    with (
+        patch("app.api.auth.AuthService") as mock_service_cls,
+        patch("app.api.auth._verify_and_remove_state", return_value=True),
+        patch("app.api.auth.limiter") as mock_limiter,
+    ):
+        mock_limiter.limit.return_value = lambda f: f
+        mock_service = mock_service_cls.return_value
+        mock_service.handle_google_callback = AsyncMock(
+            side_effect=OAuthConfigError("test")
+        )
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.get(
+            "/auth/google/callback?code=fake&state=fake_state",
+            follow_redirects=False,
+        )
+        assert "oauth_not_configured" in response.headers.get("location", "")
+
+    # 일반 Exception → auth_failed
+    with (
+        patch("app.api.auth.AuthService") as mock_service_cls,
+        patch("app.api.auth._verify_and_remove_state", return_value=True),
+        patch("app.api.auth.limiter") as mock_limiter,
+    ):
+        mock_limiter.limit.return_value = lambda f: f
+        mock_service = mock_service_cls.return_value
+        mock_service.handle_google_callback = AsyncMock(
+            side_effect=Exception("some error")
+        )
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.get(
+            "/auth/google/callback?code=fake&state=fake_state",
+            follow_redirects=False,
+        )
+        assert "auth_failed" in response.headers.get("location", "")

--- a/frontend/src/features/auth/AuthCallback.tsx
+++ b/frontend/src/features/auth/AuthCallback.tsx
@@ -80,7 +80,9 @@ export default function AuthCallback() {
         setErrorMessage(
           params.error === 'auth_failed'
             ? '인증에 실패했습니다. 다시 시도해주세요.'
-            : `인증 오류: ${params.error}`
+            : params.error === 'oauth_not_configured'
+              ? '현재 소셜 로그인 서비스를 사용할 수 없습니다. 잠시 후 다시 시도해주세요.'
+              : '인증 오류가 발생했습니다. 다시 시도해주세요.'
         );
         return;
       }


### PR DESCRIPTION
## Summary
- OAuth 크리덴셜(`GOOGLE_CLIENT_ID` 등) 미설정 시 **400 Bad Request** 대신 명확한 에러 리다이렉트(302) 반환
- `OAuthConfigError` 커스텀 예외 도입으로 시작/콜백 라우트 모두 방어
- `secrets.py`: OAuth 시크릿 미발견 시 CRITICAL 로그 + 누락 환경변수 요약
- 프론트엔드: `oauth_not_configured` 에러에 한국어 메시지 표시

## Changes (6 files)
| 파일 | 변경 내용 |
|------|----------|
| `backend/app/common/config.py` | `is_google_oauth_configured`, `is_naver_oauth_configured` 프로퍼티 추가 |
| `backend/app/auth/oauth.py` | `OAuthConfigError` 예외 클래스 + Google/Naver 4개 메서드 사전 검증 |
| `backend/app/api/auth.py` | 시작/콜백 라우트 4곳에 `OAuthConfigError` catch → 에러 리다이렉트 |
| `backend/app/common/secrets.py` | `CRITICAL_CATEGORIES` 도입, OAuth 환경변수 누락 요약 로그 |
| `frontend/src/features/auth/AuthCallback.tsx` | `oauth_not_configured` 한국어 에러 메시지 |
| `backend/scripts/testing/auth/test_oauth_config_validation.py` | 단위 테스트 10건 (all pass) |

## Test plan
- [x] `pytest scripts/testing/auth/test_oauth_config_validation.py -v -m unit` → 10 passed
- [ ] OAuth 크리덴셜 없이 서버 시작 → `/auth/google` → `#error=oauth_not_configured` 리다이렉트 확인
- [ ] OAuth 크리덴셜 설정 후 → 정상 Google/Naver 로그인 페이지 리다이렉트 확인

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)