### PR TITLE
Security: 에러 메시지 정보 노출 차단

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -163,7 +163,7 @@ async def google_callback(
 
     except Exception as e:
         logger.error(f"[Auth] Google 콜백 실패: {e}", exc_info=True)
-        error_url = f"{get_config().auth.frontend_url}/auth/error?error={str(e)}"
+        error_url = f"{get_config().auth.frontend_url}/auth/error?error=login_failed"
         return RedirectResponse(error_url)
 
 
@@ -242,7 +242,7 @@ async def naver_callback(
 
     except Exception as e:
         logger.error(f"[Auth] Naver 콜백 실패: {e}", exc_info=True)
-        error_url = f"{get_config().auth.frontend_url}/auth/error?error={str(e)}"
+        error_url = f"{get_config().auth.frontend_url}/auth/error?error=login_failed"
         return RedirectResponse(error_url)
 
 

--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -320,7 +320,10 @@ async def chat(
         rag_logger.finalize(log_entry, start_time)
         rag_logger.save(log_entry)
 
-        raise HTTPException(status_code=500, detail=f"답변 생성 중 오류 발생: {str(e)}")
+        raise HTTPException(
+            status_code=500,
+            detail="답변 생성 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.",
+        )
 
 
 async def _stream_with_heartbeat(async_iterable, heartbeat_interval: int = 15):
@@ -505,9 +508,7 @@ async def chat_stream_sse(
                         # Error during generation
                         error_event = {
                             "type": "error",
-                            "data": {
-                                "message": custom_data.get("message", "Unknown error")
-                            },
+                            "data": {"message": "답변 생성 중 오류가 발생했습니다."},
                         }
                         yield f"data: {json.dumps(error_event, ensure_ascii=False)}\n\n"
 
@@ -697,7 +698,9 @@ async def chat_stream_sse(
             rag_logger.save(log_entry)
             error_event = {
                 "type": "error",
-                "data": {"message": f"답변 생성 중 오류 발생: {str(e)}"},
+                "data": {
+                    "message": "답변 생성 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요."
+                },
             }
             yield f"data: {json.dumps(error_event, ensure_ascii=False)}\n\n"
 

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -4,6 +4,7 @@
 서버 상태 확인 및 기본 정보 제공 엔드포인트입니다.
 """
 
+import logging
 import os
 
 import httpx
@@ -14,6 +15,8 @@ from app.agents.retrieval.tools.retriever import RAGRetriever
 from app.common.config import get_config
 
 from .dependencies import get_db_config, get_retrieval_mode
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["Health"])
 
@@ -68,19 +71,15 @@ async def health_check():
         return {"status": "healthy", "database": "connected"}
 
     except Exception as e:
-        # Windows CP949/EUC-KR 로케일 이슈를 위한 안전한 문자열 변환
-        try:
-            error_msg = str(e)
-        except UnicodeDecodeError:
-            error_msg = repr(e)
-        return {"status": "unhealthy", "error": error_msg}
+        logger.error(f"[Health] DB 연결 실패: {e}")
+        return {"status": "unhealthy", "error": "서비스 연결 실패"}
 
 
 @router.get("/health/llm/supervisor")
 async def check_supervisor_llm():
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
-        return {"status": "unhealthy", "error": "OPENAI_API_KEY not found"}
+        return {"status": "unhealthy", "error": "LLM 서비스 설정 오류"}
 
     try:
         async with httpx.AsyncClient() as client:
@@ -93,19 +92,21 @@ async def check_supervisor_llm():
                 model_name = get_config().models.supervisor
                 return {"status": "healthy", "model": f"{model_name} (OpenAI API)"}
             else:
+                logger.error(f"[Health] OpenAI API 응답 오류: {response.status_code}")
                 return {
                     "status": "unhealthy",
-                    "error": f"OpenAI API returned {response.status_code}",
+                    "error": "LLM 서비스 응답 오류",
                 }
     except Exception as e:
-        return {"status": "unhealthy", "error": str(e)}
+        logger.error(f"[Health] OpenAI API 연결 실패: {e}")
+        return {"status": "unhealthy", "error": "LLM 서비스 연결 실패"}
 
 
 @router.get("/health/llm/exaone")
 async def check_exaone_llm():
     base_url = os.getenv("MODEL_EXAONE_BASE_URL") or os.getenv("EXAONE_RUNPOD_URL")
     if not base_url:
-        return {"status": "unhealthy", "error": "EXAONE URL not configured"}
+        return {"status": "unhealthy", "error": "LLM 서비스 설정 오류"}
 
     if not base_url.endswith("/v1"):
         base_url = base_url.rstrip("/") + "/v1"
@@ -116,12 +117,14 @@ async def check_exaone_llm():
             if response.status_code == 200:
                 return {"status": "healthy", "url": base_url}
             else:
+                logger.error(f"[Health] vLLM 응답 오류: {response.status_code}")
                 return {
                     "status": "unhealthy",
-                    "error": f"vLLM returned {response.status_code}",
+                    "error": "LLM 서비스 응답 오류",
                 }
     except Exception as e:
-        return {"status": "unhealthy", "error": str(e)}
+        logger.error(f"[Health] vLLM 연결 실패: {e}")
+        return {"status": "unhealthy", "error": "LLM 서비스 연결 실패"}
 
 
 @router.get("/health/embedding")
@@ -129,7 +132,7 @@ async def check_embedding():
     """OpenAI 임베딩 API 상태 확인"""
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
-        return {"status": "unhealthy", "error": "OPENAI_API_KEY not found"}
+        return {"status": "unhealthy", "error": "LLM 서비스 설정 오류"}
     return {
         "status": "healthy",
         "type": "OpenAI Embedding",


### PR DESCRIPTION
## Summary
- chat.py, health.py, auth.py의 에러 응답에서 `str(e)` 직접 노출 제거
- 클라이언트에는 일반화된 메시지 반환, 서버 로그에만 상세 에러 기록
- OAuth 에러 리다이렉트 URL에서 내부 에러 메시지 제거

Closes #168

## Test plan
- [ ] chat API 에러 시 응답에 내부 메시지 미포함 확인
- [ ] health 엔드포인트 에러 시 구현 세부사항 미노출 확인
- [ ] OAuth 에러 리다이렉트에 `error=login_failed`만 노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)