### PR TITLE
Security: 인증/인가 강화

### DIFF
--- a/backend/app/admin/dependencies.py
+++ b/backend/app/admin/dependencies.py
@@ -6,17 +6,31 @@ import logging
 import jwt
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from passlib.context import CryptContext
 
 from app.admin.models import Admin
 from app.common.config import get_config
 
 logger = logging.getLogger(__name__)
 security = HTTPBearer(auto_error=False)
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 
 def hash_password(password: str) -> str:
-    """비밀번호를 SHA-256으로 해싱합니다."""
-    return hashlib.sha256(password.encode()).hexdigest()
+    """비밀번호를 bcrypt로 해싱합니다."""
+    return pwd_context.hash(password)
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    """비밀번호를 검증합니다. bcrypt 해시와 레거시 SHA-256 모두 지원."""
+    try:
+        if pwd_context.verify(plain_password, hashed_password):
+            return True
+    except Exception:
+        pass
+    # 레거시 SHA-256 fallback (마이그레이션 기간)
+    sha256_hash = hashlib.sha256(plain_password.encode()).hexdigest()
+    return sha256_hash == hashed_password
 
 
 def create_admin_token(admin: Admin) -> str:

--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -11,7 +11,11 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from app.admin.admin_db import AdminDB
-from app.admin.dependencies import create_admin_token, get_current_admin, hash_password
+from app.admin.dependencies import (
+    create_admin_token,
+    get_current_admin,
+    verify_password,
+)
 from app.admin.models import Admin, AdminLoginRequest, AdminLoginResponse
 
 logger = logging.getLogger(__name__)
@@ -32,7 +36,7 @@ async def admin_login(request: AdminLoginRequest):
     if not admin_row:
         raise HTTPException(status_code=401, detail="Invalid credentials")
 
-    if admin_row["password_hash"] != hash_password(request.password):
+    if not verify_password(request.password, admin_row["password_hash"]):
         raise HTTPException(status_code=401, detail="Invalid credentials")
 
     admin = Admin(

--- a/backend/app/api/metrics.py
+++ b/backend/app/api/metrics.py
@@ -6,13 +6,18 @@
 
 from typing import Optional
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
+
+from app.admin.dependencies import get_current_admin
+from app.admin.models import Admin
 
 router = APIRouter(prefix="/metrics", tags=["Metrics"])
 
 
 @router.get("/agents")
-async def get_agent_metrics(agent_name: Optional[str] = None):
+async def get_agent_metrics(
+    agent_name: Optional[str] = None, admin: Admin = Depends(get_current_admin)
+):
     """
     에이전트 성능 메트릭스 조회
 
@@ -28,7 +33,7 @@ async def get_agent_metrics(agent_name: Optional[str] = None):
 
 
 @router.get("/agents/summary")
-async def get_agent_metrics_summary():
+async def get_agent_metrics_summary(admin: Admin = Depends(get_current_admin)):
     """
     전체 에이전트 성능 요약
 
@@ -41,7 +46,11 @@ async def get_agent_metrics_summary():
 
 
 @router.get("/agents/recent")
-async def get_recent_metrics(agent_name: Optional[str] = None, limit: int = 100):
+async def get_recent_metrics(
+    agent_name: Optional[str] = None,
+    limit: int = 100,
+    admin: Admin = Depends(get_current_admin),
+):
     """
     최근 메트릭 레코드 조회
 

--- a/backend/app/common/config.py
+++ b/backend/app/common/config.py
@@ -523,7 +523,7 @@ class AuthConfig(BaseSettings):
         default="HS256", alias="JWT_ALGORITHM", description="JWT 알고리즘"
     )
     jwt_token_expire_days: int = Field(
-        default=30, alias="JWT_TOKEN_EXPIRE_DAYS", description="JWT 토큰 만료 기간 (일)"
+        default=7, alias="JWT_TOKEN_EXPIRE_DAYS", description="JWT 토큰 만료 기간 (일)"
     )
 
     # Google OAuth

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -75,6 +75,28 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+# 보안 헤더 미들웨어 (SEC-07)
+from starlette.middleware.base import BaseHTTPMiddleware
+
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        response = await call_next(request)
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-XSS-Protection"] = "1; mode=block"
+        response.headers["Strict-Transport-Security"] = (
+            "max-age=31536000; includeSubDomains"
+        )
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        response.headers["Permissions-Policy"] = (
+            "camera=(), microphone=(), geolocation=()"
+        )
+        return response
+
+
+app.add_middleware(SecurityHeadersMiddleware)
+
 # Rate Limiting 설정 (SEC-04)
 from app.middleware.rate_limiter import limiter, rate_limit_exceeded_handler
 
@@ -122,6 +144,19 @@ async def startup_event():
         logger.info("[Startup] ConversationCleanupService 시작 완료")
     except Exception as e:
         logger.warning(f"[Startup] ConversationCleanupService 시작 실패: {e}")
+
+    # SEC-14: 기본 시크릿 사용 경고
+    from app.common.config import get_config
+
+    config = get_config()
+    if config.auth.jwt_secret_key == "dev_secret_key_change_in_production":
+        logger.warning(
+            "[Security] JWT_SECRET_KEY가 기본값입니다. 프로덕션에서 반드시 변경하세요!"
+        )
+    if config.db.password == "postgres":
+        logger.warning(
+            "[Security] DB_PASSWORD가 기본값입니다. 프로덕션에서 반드시 변경하세요!"
+        )
 
 
 @app.on_event("shutdown")


### PR DESCRIPTION
## Summary
- 관리자 비밀번호 bcrypt 전환 + SHA-256 레거시 fallback (SEC-08)
- JWT 만료 30일→7일 단축 (SEC-09)
- 메트릭스 엔드포인트에 관리자 인증 추가 (SEC-10)
- 보안 헤더 미들웨어 추가 (SEC-07)
- 시작 시 기본 시크릿 사용 경고 로그 (SEC-14)

Closes #176

## Test plan
- [ ] 관리자 로그인 동작 확인 (bcrypt + SHA-256 fallback)
- [ ] 보안 헤더 포함 확인
- [ ] 메트릭스 인증 없이 접근 시 401 확인
- [ ] JWT 7일 만료 설정 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)