### PR TITLE
fix: SupervisorNode LLM fallback 테스트 수정 (#184)

### DIFF
--- a/backend/scripts/testing/reliability/test_llm_timeout.py
+++ b/backend/scripts/testing/reliability/test_llm_timeout.py
@@ -115,12 +115,11 @@ class TestSupervisorLLMTimeout:
     """Supervisor LLM timeout should fallback to rule-based routing."""
 
     @pytest.mark.asyncio
-    async def test_supervisor_llm_none_uses_rule_based(self):
-        """SupervisorNode with llm=None uses rule-based routing."""
+    async def test_supervisor_llm_failure_uses_rule_based(self):
+        """SupervisorNode falls back to rule-based when LLM call fails."""
         from app.supervisor.nodes.supervisor import SupervisorNode
 
         supervisor = SupervisorNode(llm=None)
-        assert supervisor.llm is None
 
         state = {
             "user_query": "환불 가능한가요?",
@@ -133,8 +132,13 @@ class TestSupervisorLLMTimeout:
             "review": None,
         }
 
-        node_fn = supervisor.as_node()
-        result = await node_fn(state)
+        # LLM 호출을 실패시켜 rule-based fallback 검증
+        with (
+            patch.object(supervisor, "_primary_llm", None),
+            patch.object(supervisor, "_fallback_llm", None),
+        ):
+            node_fn = supervisor.as_node()
+            result = await node_fn(state)
 
         assert "supervisor" in result
         supervisor_state = result["supervisor"]


### PR DESCRIPTION
## Summary

- `test_llm_timeout.py::TestSupervisorLLMTimeout` CI 실패 수정
- `SupervisorNode(llm=None)`이 config에서 자동 LLM 로드하여 `.llm is None` assertion 실패
- `patch.object`로 `_primary_llm`, `_fallback_llm`을 None 설정하여 rule-based fallback 검증

Refs #184

## Test plan

- [x] 로컬 테스트 통과
- [x] ruff lint 통과
- [ ] CI 5개 체크 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)