### PR TITLE
fix: 프로덕션 API URL localhost 폴백 방지 (#187)

### DIFF
--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -8,6 +8,7 @@ COPY . .
 
 # Production에서는 상대 경로 사용 (nginx 프록시 통해 백엔드로 전달)
 ENV VITE_API_BASE_URL=""
+ENV VITE_BACKEND_URL=""
 RUN npm run build
 
 # Production stage

--- a/frontend/src/features/auth/LoginModal.tsx
+++ b/frontend/src/features/auth/LoginModal.tsx
@@ -20,7 +20,7 @@ const NaverIcon = () => (
 export default function LoginModal() {
   const setIsAuthModalOpen = useUIStore((state) => state.setIsAuthModalOpen);
 
-  const BACKEND_URL = import.meta.env.VITE_BACKEND_URL || 'http://localhost:8000';
+  const BACKEND_URL = import.meta.env.VITE_BACKEND_URL ?? 'http://localhost:8000';
 
   const handleGoogleLogin = () => {
     window.location.href = `${BACKEND_URL}/auth/google`;

--- a/frontend/src/features/auth/OAuthCallback.tsx
+++ b/frontend/src/features/auth/OAuthCallback.tsx
@@ -38,7 +38,7 @@ export default function OAuthCallback() {
         }
 
         // 백엔드에서 사용자 정보 가져오기
-        const BACKEND_URL = import.meta.env.VITE_BACKEND_URL || 'http://localhost:8000';
+        const BACKEND_URL = import.meta.env.VITE_BACKEND_URL ?? 'http://localhost:8000';
         const response = await fetch(`${BACKEND_URL}/auth/me`, {
           headers: {
             'Authorization': `${tokenType || 'Bearer'} ${accessToken}`,

--- a/frontend/src/features/chat/hooks/useStreamingChat.ts
+++ b/frontend/src/features/chat/hooks/useStreamingChat.ts
@@ -14,7 +14,7 @@ import type {
   OnboardingAPIData,
 } from '@/shared/types';
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8000';
 
 /**
  * Convert dispute form data to onboarding API format

--- a/frontend/src/features/mypage/MyPage.tsx
+++ b/frontend/src/features/mypage/MyPage.tsx
@@ -93,7 +93,7 @@ export default function MyPage() {
 
     try {
       // 백엔드 API 호출
-      const BACKEND_URL = import.meta.env.VITE_BACKEND_URL || 'http://localhost:8000';
+      const BACKEND_URL = import.meta.env.VITE_BACKEND_URL ?? 'http://localhost:8000';
       const response = await fetch(`${BACKEND_URL}/api/users/me/profile`, {
         method: 'PATCH',
         headers: {


### PR DESCRIPTION
## Summary
- 프론트엔드 4개 파일에서 `||` → `??` (nullish coalescing) 변경
- 빈 문자열(`""`)이 falsy로 평가되어 localhost 폴백되는 버그 수정
- `Dockerfile.prod`에 `VITE_BACKEND_URL=""` 환경변수 추가

## 변경 파일
| 파일 | 변경 |
|------|------|
| `useStreamingChat.ts:17` | `\|\|` → `??` |
| `LoginModal.tsx:23` | `\|\|` → `??` |
| `OAuthCallback.tsx:41` | `\|\|` → `??` |
| `MyPage.tsx:96` | `\|\|` → `??` |
| `Dockerfile.prod:11` | `ENV VITE_BACKEND_URL=""` 추가 |

## Test plan
- [ ] 프로덕션 빌드 성공 확인 (CI frontend-build)
- [ ] ESLint 통과 (CI frontend-lint)
- [ ] Google/Naver OAuth 리다이렉트 정상 동작
- [ ] 채팅 SSE 스트리밍 정상 동작

Refs #187

🤖 Generated with [Claude Code](https://claude.ai/claude-code)