### PR TITLE
fix: 게시글 삭제 후 게시판 접근 불가 버그 수정

### DIFF
--- a/frontend/src/features/board/BoardPage.tsx
+++ b/frontend/src/features/board/BoardPage.tsx
@@ -229,7 +229,7 @@ export default function BoardPage() {
     try {
       await boardService.deletePost(postId);
       setCurrentView('list');
-      fetchPosts(); // 목록 새로고침
+      await fetchPosts();
     } catch (err) {
       console.error('Failed to delete post:', err);
       alert('게시글 삭제에 실패했습니다.');

--- a/frontend/src/features/board/components/PostDetail.tsx
+++ b/frontend/src/features/board/components/PostDetail.tsx
@@ -10,7 +10,7 @@ interface PostDetailProps {
   postDetail: PostDetailType;
   onBack: () => void;
   onEdit: (post: BoardPost) => void;
-  onDelete: (postId: string) => void;
+  onDelete: (postId: string) => Promise<void>;
 }
 
 export default function PostDetail({ post, postDetail, onBack, onEdit, onDelete }: PostDetailProps) {
@@ -218,9 +218,16 @@ export default function PostDetail({ post, postDetail, onBack, onEdit, onDelete 
     }
   };
 
-  const handleDelete = () => {
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleDelete = async () => {
     if (window.confirm('정말 이 게시글을 삭제하시겠습니까?')) {
-      onDelete(post.id);
+      setIsDeleting(true);
+      try {
+        await onDelete(post.id);
+      } finally {
+        setIsDeleting(false);
+      }
     }
   };
 
@@ -284,10 +291,11 @@ export default function PostDetail({ post, postDetail, onBack, onEdit, onDelete 
               </button>
               <button
                 onClick={handleDelete}
-                className="flex items-center gap-2 px-4 py-2 bg-red-50 text-red-600 rounded-lg font-medium hover:bg-red-100 transition-all"
+                disabled={isDeleting}
+                className="flex items-center gap-2 px-4 py-2 bg-red-50 text-red-600 rounded-lg font-medium hover:bg-red-100 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
               >
-                <Trash2 size={16} />
-                <span className="hidden sm:inline">삭제</span>
+                {isDeleting ? <Loader2 size={16} className="animate-spin" /> : <Trash2 size={16} />}
+                <span className="hidden sm:inline">{isDeleting ? '삭제 중...' : '삭제'}</span>
               </button>
             </>
           ) : (


### PR DESCRIPTION
## Summary
- `BoardPage.tsx`: `fetchPosts()` 호출에 `await` 추가 → 삭제 후 목록 재조회 에러가 catch로 전파되도록 수정
- `PostDetail.tsx`: 삭제 버튼에 `isDeleting` 로딩 상태 추가 → 중복 클릭 방지 + 로딩 UI

## Test plan
- [ ] 게시글 삭제 후 목록이 정상 로드되는지 확인
- [ ] 삭제 버튼 연타 시 중복 삭제 요청이 발생하지 않는지 확인
- [ ] 삭제 중 로딩 스피너가 표시되는지 확인
- [ ] `npm run build` 성공 확인

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)