### PR TITLE
release: develop → main (게시글 삭제 버그 수정 포함)

### DIFF
--- a/frontend/src/features/board/BoardPage.tsx
+++ b/frontend/src/features/board/BoardPage.tsx
@@ -229,7 +229,7 @@ export default function BoardPage() {
     try {
       await boardService.deletePost(postId);
       setCurrentView('list');
-      fetchPosts(); // 목록 새로고침
+      await fetchPosts();
     } catch (err) {
       console.error('Failed to delete post:', err);
       alert('게시글 삭제에 실패했습니다.');

--- a/frontend/src/features/board/components/PostDetail.tsx
+++ b/frontend/src/features/board/components/PostDetail.tsx
@@ -10,7 +10,7 @@ interface PostDetailProps {
   postDetail: PostDetailType;
   onBack: () => void;
   onEdit: (post: BoardPost) => void;
-  onDelete: (postId: string) => void;
+  onDelete: (postId: string) => Promise<void>;
 }
 
 export default function PostDetail({ post, postDetail, onBack, onEdit, onDelete }: PostDetailProps) {
@@ -218,9 +218,16 @@ export default function PostDetail({ post, postDetail, onBack, onEdit, onDelete 
     }
   };
 
-  const handleDelete = () => {
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleDelete = async () => {
     if (window.confirm('정말 이 게시글을 삭제하시겠습니까?')) {
-      onDelete(post.id);
+      setIsDeleting(true);
+      try {
+        await onDelete(post.id);
+      } finally {
+        setIsDeleting(false);
+      }
     }
   };
 
@@ -284,10 +291,11 @@ export default function PostDetail({ post, postDetail, onBack, onEdit, onDelete 
               </button>
               <button
                 onClick={handleDelete}
-                className="flex items-center gap-2 px-4 py-2 bg-red-50 text-red-600 rounded-lg font-medium hover:bg-red-100 transition-all"
+                disabled={isDeleting}
+                className="flex items-center gap-2 px-4 py-2 bg-red-50 text-red-600 rounded-lg font-medium hover:bg-red-100 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
               >
-                <Trash2 size={16} />
-                <span className="hidden sm:inline">삭제</span>
+                {isDeleting ? <Loader2 size={16} className="animate-spin" /> : <Trash2 size={16} />}
+                <span className="hidden sm:inline">{isDeleting ? '삭제 중...' : '삭제'}</span>
               </button>
             </>
           ) : (


### PR DESCRIPTION
## Summary
- fix: `buildUrl` 로직 간결화 - 절대/상대 URL 명시적 분기
- fix: `buildUrl` fallback에서 `||` 대신 `??` 사용 + 에러 로깅 추가
- fix: post/put/delete 메서드에도 buildUrl 헬퍼 적용
- fix: 게시글 삭제 후 목록 재조회 실패 및 중복 클릭 방지 (#196)

## Test plan
- [ ] 게시글 삭제 후 목록 정상 로드 확인
- [ ] API 호출 시 URL 정상 구성 확인
- [ ] `npm run build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)