### PR TITLE
fix: /chat 새로고침 405, 세션 동기화, 세션 저장 버그 수정

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -77,8 +77,21 @@ server {
         add_header X-Accel-Buffering "no" always;
     }
 
-    # API proxy - backend endpoints
-    location /chat {
+    # API proxy - /chat/sessions (GET/POST/DELETE all go to backend)
+    location /chat/sessions {
+        proxy_pass http://backend:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # API proxy - /chat exact match (POST→backend, GET→SPA)
+    location = /chat {
+        if ($request_method != POST) {
+            rewrite ^ /index.html break;
+        }
         proxy_pass http://backend:8000;
         proxy_http_version 1.1;
         proxy_set_header Host $host;

--- a/frontend/src/app/RootLayout.tsx
+++ b/frontend/src/app/RootLayout.tsx
@@ -30,13 +30,27 @@ export default function RootLayout() {
   }, [isLoggedIn]);
 
   useEffect(() => {
-    loadChatSessions(isLoggedIn);
+    if (isLoggedIn && token) {
+      // 로그인 상태: 백엔드 동기화 우선 (5초 쿨다운)
+      const now = Date.now();
+      if (now - lastSyncTime.current > 5000) {
+        syncWithBackend(token).then(() => {
+          lastSyncTime.current = Date.now();
+        }).catch(() => {
+          loadChatSessions(true); // 동기화 실패 시 localStorage 폴백
+        });
+      } else {
+        loadChatSessions(true);
+      }
+    } else {
+      loadChatSessions(false);
+    }
 
     if (!isLoggedIn) {
       const interval = setInterval(() => loadChatSessions(false), 60000);
       return () => clearInterval(interval);
     }
-  }, [location.pathname, isLoggedIn, loadChatSessions]);
+  }, [location.pathname, isLoggedIn, token, loadChatSessions, syncWithBackend]);
 
   // 페이지 focus 시 자동 동기화 (멀티 디바이스 지원)
   useEffect(() => {

--- a/frontend/src/features/chat/ChatPage.tsx
+++ b/frontend/src/features/chat/ChatPage.tsx
@@ -194,16 +194,18 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
   };
 
   useEffect(() => {
-    // 메시지가 2개 이상일 때만 스크롤 (초기 상태에서는 스크롤하지 않음)
-    if (disputeMessages.length > 1) {
+    // 메시지가 2개 이상이고 user 메시지가 있을 때만 저장 (초기 상태에서는 저장하지 않음)
+    const hasUserMessage = disputeMessages.some(m => m.type === 'user');
+    if (disputeMessages.length > 1 && hasUserMessage) {
       scrollToBottom(disputeMessagesEndRef);
       saveChatSession('dispute', disputeMessages);
     }
   }, [disputeMessages, saveChatSession]);
 
   useEffect(() => {
-    // 메시지가 2개 이상일 때만 스크롤 (초기 상태에서는 스크롤하지 않음)
-    if (generalMessages.length > 1) {
+    // 메시지가 2개 이상이고 user 메시지가 있을 때만 저장 (초기 상태에서는 저장하지 않음)
+    const hasUserMessage = generalMessages.some(m => m.type === 'user');
+    if (generalMessages.length > 1 && hasUserMessage) {
       scrollToBottom(generalMessagesEndRef);
       saveChatSession('general', generalMessages);
     }


### PR DESCRIPTION
## Summary

- **Bug 1 - `/chat` 새로고침 405**: nginx `location /chat`을 exact match(`= /chat`)로 변경하고 POST만 백엔드로 프록시, GET은 SPA fallback. `/chat/sessions` 별도 location 추가
- **Bug 2 - 로그아웃 후 재로그인 세션 증발**: RootLayout에서 로그인 시 `syncWithBackend`를 우선 호출하여 백엔드 세션 데이터를 즉시 복원 (5초 쿨다운, 실패 시 localStorage 폴백)
- **Bug 3 - 대화 1회 시 목록 미생성**: 세션 저장 조건에 `hasUserMessage` 체크를 추가하여 user 메시지가 있을 때만 저장하도록 명확화

## Test plan

- [ ] `/chat` 페이지에서 F5 새로고침 → SPA 정상 표시 (405 에러 없음)
- [ ] POST `/chat` API → 백엔드로 정상 프록시
- [ ] GET/POST `/chat/sessions` → 백엔드로 정상 프록시
- [ ] `/chat/stream` SSE → 기존과 동일하게 동작
- [ ] 로그아웃 → 재로그인 → 이전 상담 내역 유지
- [ ] 분쟁 상담: 온보딩 폼 제출 + AI 응답 1회 → 사이드바 목록 생성
- [ ] 일반 상담: 메시지 1회 전송 + AI 응답 → 사이드바 목록 생성
- [ ] 비로그인 상태 세션 저장 정상 동작

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)