### PR TITLE
hotfix: nginx crash loop 수정 (limit_except → if rewrite)

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -87,9 +87,10 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    # API proxy - /chat exact match (POST→backend, GET→SPA)
+    # API proxy - /chat exact match (POST→backend, GET→SPA fallback)
+    # Note: "if" with "rewrite break" in location context is a safe, well-tested pattern
     location = /chat {
-        limit_except POST {
+        if ($request_method != POST) {
             rewrite ^ /index.html break;
         }
         proxy_pass http://backend:8000;


### PR DESCRIPTION
## Summary

- nginx `limit_except` + `rewrite` 조합이 `[emerg] "rewrite" directive is not allowed here` 에러를 발생시켜 frontend 컨테이너 crash loop 유발
- `if ($request_method != POST) { rewrite ^ /index.html break; }` 패턴으로 복원 (location context에서 안전한 패턴)

## Context

PR #207에서 머지된 `limit_except` 변경이 deploy-staging에서 nginx crash를 유발. 이 PR은 해당 hotfix만 포함.

Refs #205

## Test plan

- [ ] nginx 정상 시작 (`docker exec frontend nginx -t`)
- [ ] GET `/chat` → SPA 정상 표시
- [ ] POST `/chat` → 백엔드 프록시 정상
- [ ] deploy-staging health check 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)