### PR TITLE
fix: /chat SPA fallback 404 + 세션 증발 race condition (develop → main)

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -87,11 +87,11 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    # API proxy - /chat exact match (POST→backend, GET→SPA fallback)
-    # Note: "if" with "rewrite break" in location context is a safe, well-tested pattern
+    # /chat - GET→SPA fallback, POST→backend proxy
     location = /chat {
+        error_page 418 = @spa_fallback;
         if ($request_method != POST) {
-            rewrite ^ /index.html break;
+            return 418;
         }
         proxy_pass http://backend:8000;
         proxy_http_version 1.1;
@@ -99,6 +99,12 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # SPA fallback (named location for non-POST /chat requests)
+    location @spa_fallback {
+        root /usr/share/nginx/html;
+        try_files /index.html =404;
     }
 
     location /search {

--- a/frontend/src/app/RootLayout.tsx
+++ b/frontend/src/app/RootLayout.tsx
@@ -51,7 +51,7 @@ export default function RootLayout() {
       const interval = setInterval(() => loadChatSessions(false), 60000);
       return () => clearInterval(interval);
     }
-  }, [location.pathname, isLoggedIn, token, loadChatSessions, syncWithBackend]);
+  }, [isLoggedIn, token, loadChatSessions, syncWithBackend]);
 
   // 페이지 focus 시 자동 동기화 (멀티 디바이스 지원)
   useEffect(() => {

--- a/frontend/src/features/chat/chat.store.ts
+++ b/frontend/src/features/chat/chat.store.ts
@@ -87,6 +87,7 @@ interface ChatState {
   isFormSubmitted: boolean;
   backendSessionId: string | null;
   disputeFormData: DisputeFormData | null;
+  isSyncing: boolean;
 
   // Actions
   setCurrentSessionId: (id: string | null) => void;
@@ -129,6 +130,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
   isFormSubmitted: false,
   backendSessionId: null,
   disputeFormData: null,
+  isSyncing: false,
 
   setCurrentSessionId: (id) => set({ currentSessionId: id }),
   setActiveChatType: (type) => set({ activeChatType: type }),
@@ -142,6 +144,11 @@ export const useChatStore = create<ChatState>((set, get) => ({
   setDisputeFormData: (data) => set({ disputeFormData: data }),
 
   loadChatSessions: (isLoggedIn) => {
+    // 동기화 중이면 로드 건너뛰기 (race condition 방지)
+    if (get().isSyncing) {
+      console.log('[ChatStore] Skipping loadChatSessions — sync in progress');
+      return;
+    }
     let storageKey: string;
     let userId: string | null = null;
 
@@ -354,6 +361,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
   },
 
   syncWithBackend: async (token: string) => {
+    set({ isSyncing: true });
     try {
       const userId = getCurrentUserId();
       if (!userId) {
@@ -454,6 +462,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
         const visibleSessions = filterHiddenSessions(localSessions, userId);
         set({ chatSessions: visibleSessions });
       }
+    } finally {
+      set({ isSyncing: false });
     }
   },
 }));


### PR DESCRIPTION
## Summary
develop → main 머지. PR #210 포함.

- **Bug 1**: `/chat` F5 새로고침 시 404 → `error_page 418 + @spa_fallback` 패턴으로 수정
- **Bug 2**: 채팅 내역 증발 race condition → `isSyncing` 플래그 + `location.pathname` 의존성 제거

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)