### PR TITLE
fix: F5 새로고침 시 채팅 데이터 증발 (auth hydration race)

### DIFF
--- a/frontend/src/app/RootLayout.tsx
+++ b/frontend/src/app/RootLayout.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useLayoutEffect, useRef } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { Outlet, useLocation, ScrollRestoration } from 'react-router-dom';
 import { Menu } from 'lucide-react';
 import { useUIStore } from '@/store';
-import { useAuthStore } from '@/features/auth/auth.store';
+import { useAuthStore, isAuthHydrated } from '@/features/auth/auth.store';
 import { useChatStore } from '@/features/chat/chat.store';
 import Sidebar from '@/widgets/Sidebar';
 import LoginModal from '@/features/auth/LoginModal';
@@ -20,16 +20,36 @@ export default function RootLayout() {
   const lastSyncTime = useRef<number>(0);
   const prevAuthRef = useRef(isLoggedIn);
 
+  // Auth hydration 완료 대기 (F5 새로고침 시 race condition 방지)
+  const [authReady, setAuthReady] = useState(isAuthHydrated());
+
+  useEffect(() => {
+    if (isAuthHydrated()) {
+      setAuthReady(true);
+      return;
+    }
+    const check = setInterval(() => {
+      if (isAuthHydrated()) {
+        setAuthReady(true);
+        clearInterval(check);
+      }
+    }, 10);
+    return () => clearInterval(check);
+  }, []);
+
   // 로그아웃 감지 시 chatStore 상태 초기화 (순환 참조 방지)
   useEffect(() => {
+    if (!authReady) return;
     if (prevAuthRef.current && !isLoggedIn) {
       useChatStore.getState().resetState();
       console.log('[RootLayout] Auth state changed to logged out — chat state reset');
     }
     prevAuthRef.current = isLoggedIn;
-  }, [isLoggedIn]);
+  }, [authReady, isLoggedIn]);
 
   useEffect(() => {
+    if (!authReady) return;
+
     if (isLoggedIn && token) {
       // 로그인 상태: 백엔드 동기화 우선 (5초 쿨다운)
       const now = Date.now();
@@ -51,7 +71,7 @@ export default function RootLayout() {
       const interval = setInterval(() => loadChatSessions(false), 60000);
       return () => clearInterval(interval);
     }
-  }, [isLoggedIn, token, loadChatSessions, syncWithBackend]);
+  }, [authReady, isLoggedIn, token, loadChatSessions, syncWithBackend]);
 
   // 페이지 focus 시 자동 동기화 (멀티 디바이스 지원)
   useEffect(() => {

--- a/frontend/src/features/auth/auth.store.ts
+++ b/frontend/src/features/auth/auth.store.ts
@@ -58,6 +58,10 @@ const transferGuestSessions = async (userId: string, token: string) => {
   console.log(`[Auth] Transferred ${guestSessions.length} guest sessions to user ${userId}`);
 };
 
+// Auth hydration 상태 추적 (F5 새로고침 시 race condition 방지)
+let _isAuthHydrated = false;
+export const isAuthHydrated = () => _isAuthHydrated;
+
 export const useAuthStore = create<AuthState>()(
   persist(
     (set) => ({
@@ -79,6 +83,11 @@ export const useAuthStore = create<AuthState>()(
     }),
     {
       name: STORAGE_KEYS.USER_DATA,
+      onRehydrateStorage: () => {
+        return () => {
+          _isAuthHydrated = true;
+        };
+      },
     }
   )
 );


### PR DESCRIPTION
## Summary
- F5 새로고침 시 Zustand persist hydration이 완료되기 전에 `loadChatSessions`이 호출되어 빈 게스트 키로 조회 → 채팅 데이터가 증발하는 race condition 수정
- `auth.store.ts`에 `isAuthHydrated()` 헬퍼 + `onRehydrateStorage` 콜백 추가
- `RootLayout.tsx`에 `authReady` guard 추가하여 hydration 완료까지 세션 로딩 지연

## Root Cause
```
T0: F5 → state 리셋 → isAuthenticated=false
T1: useEffect → loadChatSessions(false) → 게스트 키 조회 → 빈 배열로 덮어씀
T2: persist hydration 완료 → isAuthenticated=true (이미 늦음)
```

## Fix
```
T0: F5 → state 리셋, authReady=false
T1: useEffect → authReady=false → return (아무것도 안함)
T2: persist hydration 완료 → authReady=true
T3: useEffect 재실행 → 올바른 auth 상태로 세션 로딩
```

## Test plan
- [ ] 로그인 상태에서 F5 → 세션 목록 유지
- [ ] 3회 연속 F5 → 데이터 손실 없음
- [ ] 비로그인 F5 → 게스트 세션 유지
- [ ] 로그아웃→재로그인 → 이전 채팅 복원

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)