### PR TITLE
fix: enable DB persistence for chat sessions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,7 +97,7 @@ CACHE_LOG_LEVEL=INFO
 # 대화 메모리 설정
 # =============================================================================
 # memory: 인메모리 (기본), db: PostgreSQL 영구 저장
-CONVERSATION_MEMORY_BACKEND=memory
+CONVERSATION_MEMORY_BACKEND=db
 MAX_CONVERSATION_TURNS=30
 SLIDING_WINDOW_SIZE=10
 GUEST_SESSION_TTL_HOURS=24

--- a/frontend/src/features/chat/chat.store.ts
+++ b/frontend/src/features/chat/chat.store.ts
@@ -441,16 +441,27 @@ export const useChatStore = create<ChatState>((set, get) => ({
         }
       }
 
+      // 백엔드에 없지만 최근 5분 이내 생성된 로컬 세션 보존 (DB 저장 지연 방어)
+      const backendSessionIds = new Set(convertedSessions.map(s => s.id));
+      const recentLocalOnly = localSessions.filter(
+        s => !backendSessionIds.has(s.id) && s.lastUpdated && (Date.now() - s.lastUpdated < 5 * 60 * 1000)
+      );
+      const mergedSessions = [...convertedSessions, ...recentLocalOnly];
+
+      if (recentLocalOnly.length > 0) {
+        console.log(`[ChatStore] Preserved ${recentLocalOnly.length} recent local-only sessions`);
+      }
+
       // 숨긴 세션 필터링
-      const visibleSessions = filterHiddenSessions(convertedSessions, userId);
+      const visibleSessions = filterHiddenSessions(mergedSessions, userId);
 
       // localStorage에 저장 (필터링되지 않은 전체 세션 저장 - 숨김 해제 가능하도록)
-      storage.set(storageKey, convertedSessions, false);
+      storage.set(storageKey, mergedSessions, false);
 
       // state 업데이트 (필터링된 세션만)
       set({ chatSessions: visibleSessions });
 
-      console.log(`[ChatStore] Sync complete: ${visibleSessions.length} sessions (${convertedSessions.length - visibleSessions.length} hidden)`);
+      console.log(`[ChatStore] Sync complete: ${visibleSessions.length} sessions (${mergedSessions.length - visibleSessions.length} hidden)`);
     } catch (error) {
       console.error('[ChatStore] syncWithBackend failed:', error);
       // 동기화 실패 시 localStorage 데이터 사용


### PR DESCRIPTION
## Summary
- **Root cause**: `CONVERSATION_MEMORY_BACKEND=memory` caused chat sessions to be stored only in-memory, never persisted to PostgreSQL
- **Secondary issue**: `syncWithBackend` replaced local sessions entirely with backend results — when backend returned empty (due to no DB writes), all local sessions were permanently deleted
- Changes default `CONVERSATION_MEMORY_BACKEND` to `db`
- Adds defensive MERGE logic in `syncWithBackend`: preserves recent local-only sessions (< 5 min old) that haven't synced to backend yet

## Root Cause Analysis

```
CONVERSATION_MEMORY_BACKEND=memory
  → chat.py: use_db = False
  → ConversationMemory(use_db=False) → in-memory only, no DB writes
  → GET /chat/sessions → empty result from DB
  → syncWithBackend → replaces localStorage with empty array
  → Sessions permanently lost after F5
```

## Changes
| File | Change |
|------|--------|
| env example | `CONVERSATION_MEMORY_BACKEND=db` |
| `frontend/src/features/chat/chat.store.ts` | MERGE logic in syncWithBackend |

## Test plan
- [ ] Verify backend logs show `Memory backend: db, use_db: True`
- [ ] Send chat message → verify conversation created in DB
- [ ] `GET /chat/sessions` returns session list
- [ ] F5 refresh → sessions persist
- [ ] New tab → sessions sync correctly
- [ ] Recent local sessions preserved during sync delay

Generated with [Claude Code](https://claude.com/claude-code)
