### PR TITLE
fix: 채팅 버그 3건 수정 (PR #218 regression + DB 미저장 진단)

### DIFF
--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -622,6 +622,13 @@ async def chat_stream_sse(
                 # 어시스턴트 응답을 메모리에 추가
                 if session_memory:
                     await session_memory.add_turn(role="assistant", content=answer)
+                    logger.info(
+                        f"[chat_stream] Memory save status: "
+                        f"conversation_id={session_memory.conversation_id}, "
+                        f"use_db={session_memory.use_db}, "
+                        f"turns={session_memory.get_turn_count()}, "
+                        f"session={session_id[:8]}"
+                    )
 
                 complete_event = {"type": "complete", "data": response_data}
 

--- a/backend/app/supervisor/memory.py
+++ b/backend/app/supervisor/memory.py
@@ -196,7 +196,12 @@ class ConversationMemory:
 
             self._db_loaded = True
         except Exception as e:
-            logger.error(f"[Memory] Failed to load from DB: {e}", exc_info=True)
+            logger.error(
+                f"[Memory] Failed to load from DB: {e}, "
+                f"session_id={self.session_id}, user_id={self.user_id}, "
+                f"chat_type={self.chat_type}",
+                exc_info=True,
+            )
             # Continue with in-memory mode
             self.use_db = False
             self.db = None

--- a/frontend/src/features/chat/ChatPage.tsx
+++ b/frontend/src/features/chat/ChatPage.tsx
@@ -31,6 +31,12 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
   const isTransitioningRef = useRef(false);
   const resolvedSessionId = currentSessionId ?? storeSessionId;
 
+  // Bug 1 fix: Track previous session ID to detect actual session switches
+  // undefined = initial mount (never seen a session), null = new chat, string = specific session
+  const prevSessionIdRef = useRef<string | null | undefined>(undefined);
+  // Bug 2 fix: Track all transition timers for cleanup on rapid switches
+  const transitionTimersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
+
   // 현재 세션 ID
   const [sessionId, setSessionId] = useState<string | null>(resolvedSessionId);
 
@@ -97,13 +103,31 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
 
   // 세션 불러오기
   useEffect(() => {
+    // Bug 2 fix: Cancel all pending timers from previous transition
+    transitionTimersRef.current.forEach(clearTimeout);
+    transitionTimersRef.current = [];
+
+    // Bug 1 fix: Skip if resolvedSessionId hasn't actually changed (spurious re-trigger)
+    if (prevSessionIdRef.current !== undefined
+        && prevSessionIdRef.current === resolvedSessionId) {
+      return;
+    }
+
+    // Bug 1 fix: Only cancel streams on actual session switch (not initial mount)
+    const isSessionSwitch = prevSessionIdRef.current !== undefined
+      && prevSessionIdRef.current !== resolvedSessionId;
+
+    prevSessionIdRef.current = resolvedSessionId;
+
     // Synchronous ref lock (immediate, no batching delay)
     isTransitioningRef.current = true;
     setIsTransitioning(true);
 
-    // Cancel any active streams during session transition
-    cancelDisputeStream();
-    cancelGeneralStream();
+    // Cancel active streams only on actual session switch
+    if (isSessionSwitch) {
+      cancelDisputeStream();
+      cancelGeneralStream();
+    }
 
     if (resolvedSessionId) {
       setSessionId(resolvedSessionId);
@@ -124,7 +148,7 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
             ...msg,
             timestamp: msg.timestamp instanceof Date ? msg.timestamp : new Date(msg.timestamp)
           }))
-          .sort((a, b) => a.id - b.id); // ✅ id 오름차순 정렬
+          .sort((a, b) => a.id - b.id); // id 오름차순 정렬
 
         // store에서 설정한 chatType을 우선 사용, 없으면 세션의 type 사용
         const chatType = storeActiveChatType || session.type;
@@ -134,24 +158,27 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
           setActiveChatType('dispute');
           setIsFormSubmitted(true);
           setStoreChatType('dispute');
-          // 기존 상담 불러올 때 스크롤을 아래로 이동 (RootLayout 스크롤 처리 이후 실행)
-          setTimeout(() => {
+          // Bug 2 fix: Register scroll timer for cleanup
+          const scrollTimer = setTimeout(() => {
             disputeMessagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
           }, 200);
+          transitionTimersRef.current.push(scrollTimer);
         } else {
           setGeneralMessages(restoredMessages);
           setActiveChatType('general');
           setStoreChatType('general');
-          // 기존 상담 불러올 때 스크롤을 아래로 이동 (RootLayout 스크롤 처리 이후 실행)
-          setTimeout(() => {
+          // Bug 2 fix: Register scroll timer for cleanup
+          const scrollTimer = setTimeout(() => {
             generalMessagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
           }, 200);
+          transitionTimersRef.current.push(scrollTimer);
         }
-        // Unlock transition after messages and scroll are fully settled
-        setTimeout(() => {
+        // Bug 2 fix: Register unlock timer for cleanup
+        const unlockTimer = setTimeout(() => {
           isTransitioningRef.current = false;
           setIsTransitioning(false);
         }, 300);
+        transitionTimersRef.current.push(unlockTimer);
       } else if (storeActiveChatType) {
         // 세션이 없지만 store에 chatType이 설정되어 있는 경우
         setActiveChatType(storeActiveChatType);
@@ -196,6 +223,12 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
       isTransitioningRef.current = false;
       setIsTransitioning(false);
     }
+
+    // Bug 2 fix: Cleanup all timers on unmount or next re-trigger
+    return () => {
+      transitionTimersRef.current.forEach(clearTimeout);
+      transitionTimersRef.current = [];
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [resolvedSessionId, setStoreChatType, setStoreSessionId, storeSessionId, storeActiveChatType]);
 


### PR DESCRIPTION
## Summary

develop → main 머지. PR #224 포함.

- **Bug 1 (첫 응답 무반응)**: `prevSessionIdRef`로 spurious re-trigger 방지, 실제 세션 전환 시에만 스트림 취소
- **Bug 2 (빠른 전환 덮어쓰기)**: `transitionTimersRef`로 모든 setTimeout 관리 + useEffect cleanup
- **Bug 3 (DB 미저장 진단)**: 에러 로그에 session_id/user_id 추가, SSE endpoint에 conversation_id/use_db 로그 추가

Closes #223

## Test plan

- [ ] 분쟁 상담 온보딩 폼 제출 → AI 응답 정상 수신
- [ ] 빠른 세션 전환 → 메시지 오염 없음
- [ ] 백엔드 로그에서 DB 저장 상태 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)