### PR TITLE
fix: CONVERSATION_MEMORY_BACKEND 환경변수 프로덕션 compose에 추가

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -45,6 +45,9 @@ services:
       # === Logging ===
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
 
+      # === Memory Backend ===
+      - CONVERSATION_MEMORY_BACKEND=${CONVERSATION_MEMORY_BACKEND:-db}
+
       # === Environment ===
       - ENVIRONMENT=production
 


### PR DESCRIPTION
## Summary

- `docker-compose.prod.yml`에 `CONVERSATION_MEMORY_BACKEND` 환경변수가 누락되어 프로덕션 백엔드가 인메모리 모드(`memory`)로 동작, DB에 대화가 저장되지 않던 문제 수정
- 기본값 `db`로 설정하여 PostgreSQL에 대화 내역 저장

Closes #223

## Test plan

- [x] EC2에서 환경변수 추가 후 백엔드 재시작 → `CONVERSATION_MEMORY_BACKEND=db` 확인 완료
- [ ] 채팅 후 DBeaver에서 conversations/conversation_turns 행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)