### PR TITLE
fix: Docker 빌드 캐시 scope에서 hashFiles 제거

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,8 +62,8 @@ jobs:
           push: true
           tags: ${{ steps.meta-backend.outputs.tags }}
           labels: ${{ steps.meta-backend.outputs.labels }}
-          cache-from: type=gha,scope=backend-${{ hashFiles('backend/requirements.txt') }}
-          cache-to: type=gha,mode=max,scope=backend-${{ hashFiles('backend/requirements.txt') }}
+          cache-from: type=gha,scope=backend
+          cache-to: type=gha,mode=max,scope=backend
 
       - name: Build and push frontend
         uses: docker/build-push-action@v5
@@ -73,5 +73,5 @@ jobs:
           push: true
           tags: ${{ steps.meta-frontend.outputs.tags }}
           labels: ${{ steps.meta-frontend.outputs.labels }}
-          cache-from: type=gha,scope=frontend-${{ hashFiles('frontend/package-lock.json') }}
-          cache-to: type=gha,mode=max,scope=frontend-${{ hashFiles('frontend/package-lock.json') }}
+          cache-from: type=gha,scope=frontend
+          cache-to: type=gha,mode=max,scope=frontend


### PR DESCRIPTION
## Summary

- `build.yml`의 Docker 빌드 캐시 scope가 `hashFiles('package-lock.json')` 기반이라, **의존성 파일이 안 바뀌면 소스 코드가 바뀌어도 캐시된 이미지를 재사용**하는 문제
- 프론트엔드/백엔드 코드 변경이 ECR 이미지에 반영되지 않는 근본 원인
- 고정 scope (`frontend`, `backend`)로 변경하여 BuildKit 레이어별 캐시 무효화가 정상 동작하도록 수정

## Test plan

- [ ] main merge 후 Build and Push workflow 실행 → 프론트엔드 코드 변경 반영 확인
- [ ] EC2에서 새 이미지 pull → 수정된 ChatPage.tsx 반영 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)