### PR TITLE
fix: 첫 메시지 스트림 취소 버그 수정 (null→ID 세션 전환 오인)

### DIFF
--- a/frontend/src/features/chat/ChatPage.tsx
+++ b/frontend/src/features/chat/ChatPage.tsx
@@ -113,9 +113,11 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
       return;
     }
 
-    // Bug 1 fix: Only cancel streams on actual session switch (not initial mount)
+    // Bug 1 fix: Only cancel streams on actual session switch (ID_A → ID_B)
+    // null → ID is session "creation" (not a switch), so don't cancel streams
     const isSessionSwitch = prevSessionIdRef.current !== undefined
-      && prevSessionIdRef.current !== resolvedSessionId;
+      && prevSessionIdRef.current !== resolvedSessionId
+      && prevSessionIdRef.current !== null;
 
     prevSessionIdRef.current = resolvedSessionId;
 


### PR DESCRIPTION
## Summary
- `saveChatSession()`이 `storeSessionId`를 `null→새ID`로 변경 시 `isSessionSwitch`가 true로 판정되어 진행 중 SSE 스트림을 취소하던 버그 수정
- `null→ID`는 세션 **생성**이므로 스트림을 취소하면 안 됨
- `prevSessionIdRef.current !== null` 조건 1줄 추가

## Root cause
```
사용자 첫 메시지 전송
→ saveChatSession() 호출
→ storeSessionId: null → "abc123"
→ resolvedSessionId 변경
→ useEffect 재실행
→ isSessionSwitch = (null !== undefined && null !== "abc123") = true  ← 여기가 문제!
→ cancelDisputeStream() / cancelGeneralStream() 호출
→ SSE 연결 끊김
→ "Client disconnected during streaming" 백엔드 로그
```

## Fix
```typescript
// Before (null→ID를 세션 전환으로 오인)
const isSessionSwitch = prevSessionIdRef.current !== undefined
  && prevSessionIdRef.current !== resolvedSessionId;

// After (null→ID는 세션 생성으로 정확히 구분)
const isSessionSwitch = prevSessionIdRef.current !== undefined
  && prevSessionIdRef.current !== resolvedSessionId
  && prevSessionIdRef.current !== null;
```

## Test plan
- [ ] 분쟁 상담 온보딩 폼 제출 → AI 첫 응답 수신 확인
- [ ] 일반 상담 첫 메시지 → AI 응답 수신 확인
- [ ] 기존 세션 간 전환 시 스트림 정상 취소 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)