### PR TITLE
fix: 첫 메시지 스트림 취소 버그 수정 반영

### DIFF
--- a/frontend/src/features/chat/ChatPage.tsx
+++ b/frontend/src/features/chat/ChatPage.tsx
@@ -113,9 +113,11 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
       return;
     }
 
-    // Bug 1 fix: Only cancel streams on actual session switch (not initial mount)
+    // Bug 1 fix: Only cancel streams on actual session switch (ID_A → ID_B)
+    // null → ID is session "creation" (not a switch), so don't cancel streams
     const isSessionSwitch = prevSessionIdRef.current !== undefined
-      && prevSessionIdRef.current !== resolvedSessionId;
+      && prevSessionIdRef.current !== resolvedSessionId
+      && prevSessionIdRef.current !== null;
 
     prevSessionIdRef.current = resolvedSessionId;
 


### PR DESCRIPTION
## Summary
- PR #231 반영: 첫 메시지 전송 시 SSE 스트림이 취소되던 버그 수정
- `null→ID` 세션 생성을 세션 전환으로 오인하던 조건 수정 (1줄)

## Test plan
- [ ] 첫 메시지 AI 응답 수신 확인
- [ ] 세션 간 전환 시 스트림 정상 취소 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)