### PR TITLE
fix: 세션 전환 시 메시지 덮어쓰기 버그 수정

### DIFF
--- a/frontend/src/features/chat/ChatPage.tsx
+++ b/frontend/src/features/chat/ChatPage.tsx
@@ -335,7 +335,8 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
       });
 
       // 스트림 응답 후 세션이 전환됐는지 확인 (버퍼에 남은 데이터로 인한 오염 방지)
-      if (isTransitioningRef.current || resolvedSessionId !== expectedSessionId) {
+      // store에서 직접 읽어야 함 - 클로저의 resolvedSessionId는 렌더 시점 값이라 변하지 않음
+      if (isTransitioningRef.current || useChatStore.getState().currentSessionId !== expectedSessionId) {
         return;
       }
 
@@ -464,7 +465,8 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
       });
 
       // 스트림 응답 후 세션이 전환됐는지 확인 (버퍼에 남은 데이터로 인한 오염 방지)
-      if (isTransitioningRef.current || resolvedSessionId !== expectedSessionId) {
+      // store에서 직접 읽어야 함 - 클로저의 resolvedSessionId는 렌더 시점 값이라 변하지 않음
+      if (isTransitioningRef.current || useChatStore.getState().currentSessionId !== expectedSessionId) {
         return;
       }
 
@@ -537,7 +539,8 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
       });
 
       // 스트림 응답 후 세션이 전환됐는지 확인 (버퍼에 남은 데이터로 인한 오염 방지)
-      if (isTransitioningRef.current || resolvedSessionId !== expectedSessionId) {
+      // store에서 직접 읽어야 함 - 클로저의 resolvedSessionId는 렌더 시점 값이라 변하지 않음
+      if (isTransitioningRef.current || useChatStore.getState().currentSessionId !== expectedSessionId) {
         return;
       }
 


### PR DESCRIPTION
## Summary

- 세션 전환 시 이전 세션의 스트림 응답이 새 세션에 덮어쓰이는 버그 수정
- `cancelStream()` 호출 후에도 SSE 버퍼에 남은 데이터가 처리되어 세션 오염 발생하는 문제 해결
- 스트림 핸들러 3곳에 `expectedSessionId` 가드 추가 (1차 방어)
- 자동 저장 useEffect 2곳에 store/local 세션 ID 일관성 체크 추가 (2차 방어)

## Test plan

- [ ] 스트리밍 중 세션 전환: 세션 A에서 질문 → AI 응답 중 세션 B 클릭 → B에 A 메시지 없음
- [ ] 빠른 연속 전환: A→B→C→A → 각 세션 메시지 무결성 확인
- [ ] 정상 대화: 세션 내 메시지 주고받기 → 저장 정상 동작
- [ ] 새 세션 생성: 첫 메시지 전송 → 정상 저장

🤖 Generated with [Claude Code](https://claude.com/claude-code)