### PR TITLE
fix: 대화 내역 버그 종합 수정 7건

### DIFF
--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -685,9 +685,20 @@ async def chat_stream_sse(
             logger.info(
                 f"[chat_stream] Client disconnected during streaming, session={session_id[:8]}"
             )
+            # BUG-6 fix: 부분 응답이 있으면 assistant turn으로 저장
+            if full_answer and session_memory:
+                try:
+                    await session_memory.add_turn(role="assistant", content=full_answer)
+                    logger.info(
+                        f"[chat_stream] Saved partial answer ({len(full_answer)} chars) on cancel"
+                    )
+                except Exception as save_err:
+                    logger.error(
+                        f"[chat_stream] Failed to save partial answer: {save_err}"
+                    )
             rag_logger.log_response(
                 entry=log_entry,
-                answer="",
+                answer=full_answer or "",
                 chunks_used=0,
                 sources_count=0,
                 status="cancelled",

--- a/backend/app/supervisor/memory.py
+++ b/backend/app/supervisor/memory.py
@@ -246,6 +246,10 @@ class ConversationMemory:
                 )
             except Exception as e:
                 logger.error(f"[Memory] Failed to save turn to DB: {e}", exc_info=True)
+                # BUG-5 fix: user 메시지 저장 실패 시 예외 전파하여 API에서 500 반환
+                # assistant 응답은 재생성 가능하므로 삼킴
+                if role == "user":
+                    raise
 
         # Compact 트리거 체크
         if self._should_compact():

--- a/frontend/src/features/chat/ChatPage.tsx
+++ b/frontend/src/features/chat/ChatPage.tsx
@@ -144,6 +144,11 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
       const session = currentSessions.find(s => s.id === resolvedSessionId);
 
       if (session) {
+        // BUG-1 fix: 세션 전환 시 backendSessionId를 해당 세션 ID로 동기화
+        // 이렇게 하지 않으면 이전 세션의 backendSessionId가 남아있어
+        // saveChatSession에서 잘못된 세션에 메시지가 저장됨
+        setBackendSessionId(session.id);
+
         // 메시지를 id(turn_number) 순서로 정렬 (혹시 역순으로 저장된 경우 대비)
         const restoredMessages = session.messages
           .map(msg => ({
@@ -175,12 +180,10 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
           }, 200);
           transitionTimersRef.current.push(scrollTimer);
         }
-        // Bug 2 fix: Register unlock timer for cleanup
-        const unlockTimer = setTimeout(() => {
-          isTransitioningRef.current = false;
-          setIsTransitioning(false);
-        }, 300);
-        transitionTimersRef.current.push(unlockTimer);
+        // BUG-4 fix: 메시지 복원 완료 후 즉시 전환 가드 해제 (300ms 타이머 대신)
+        // 스크롤 타이머는 UX용이므로 유지하되 전환 가드와 분리
+        isTransitioningRef.current = false;
+        setIsTransitioning(false);
       } else if (storeActiveChatType) {
         // 세션이 없지만 store에 chatType이 설정되어 있는 경우
         setActiveChatType(storeActiveChatType);
@@ -310,7 +313,7 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
       timestamp: new Date()
     };
 
-    setDisputeMessages([...disputeMessages, formMessage]);
+    setDisputeMessages(prev => [...prev, formMessage]);
     setIsFormSubmitted(true);
     setStoreChatType('dispute');
     setActiveChatType('dispute');
@@ -418,7 +421,6 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
 
       // 의미있는 질문 (최소 5글자)
       if (line.length >= 5) {
-        console.warn('[ChatPage] Detected conversation history in input, extracted:', line.substring(0, 50));
         return line;
       }
     }
@@ -434,14 +436,8 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
     // 핸들러 진입 시 세션 ID 캡처 (스트림 응답 후 세션 전환 감지용)
     const expectedSessionId = resolvedSessionId;
 
-    // DEBUG: 원본 입력값 로깅
-    console.log('[ChatPage] Original disputeInputValue (length=' + disputeInputValue.length + '):', disputeInputValue.substring(0, 100));
-
     // Phase 2-16: 입력 텍스트 정제 (대화 히스토리 제거)
     const cleanedInput = cleanUserInput(disputeInputValue);
-
-    // DEBUG: 정제 후 로깅
-    console.log('[ChatPage] Cleaned input (length=' + cleanedInput.length + '):', cleanedInput.substring(0, 100));
 
     const newMessage: MessageWithCitations = {
       id: disputeMessages.length + 1,
@@ -450,7 +446,7 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
       timestamp: new Date()
     };
 
-    setDisputeMessages([...disputeMessages, newMessage]);
+    setDisputeMessages(prev => [...prev, newMessage]);
     setDisputeInputValue('');
 
     // AI 메시지 ID 미리 생성 (placeholder 없이)
@@ -522,7 +518,7 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
       timestamp: new Date()
     };
 
-    setGeneralMessages([...generalMessages, newMessage]);
+    setGeneralMessages(prev => [...prev, newMessage]);
     setGeneralInputValue('');
     setActiveChatType('general');
     setStoreChatType('general');

--- a/frontend/src/features/chat/chat.store.ts
+++ b/frontend/src/features/chat/chat.store.ts
@@ -8,6 +8,13 @@ import { getUserSessions, getSessionHistory, convertBackendSessionToLocal } from
 import { useAuthStore } from '@/features/auth/auth.store';
 
 /**
+ * BUG-3 fix: saveChatSession 직렬화 큐
+ * 동시에 dispute/general useEffect가 fire하면 localStorage read-modify-write 경쟁 발생.
+ * Promise 체이닝으로 save 호출을 직렬화하여 마지막 쓰기만 남는 문제를 방지.
+ */
+let saveQueue: Promise<void> = Promise.resolve();
+
+/**
  * 현재 로그인한 사용자 ID를 가져옵니다.
  * Zustand의 in-memory 상태에서 직접 읽어 레이스 컨디션을 방지합니다.
  */
@@ -150,7 +157,6 @@ export const useChatStore = create<ChatState>((set, get) => ({
   loadChatSessions: (isLoggedIn) => {
     // 동기화 중이면 로드 건너뛰기 (race condition 방지)
     if (get().isSyncing) {
-      console.log('[ChatStore] Skipping loadChatSessions — sync in progress');
       return;
     }
     let storageKey: string;
@@ -180,125 +186,103 @@ export const useChatStore = create<ChatState>((set, get) => ({
     set({ chatSessions: sessions });
   },
 
-  saveChatSession: async (type, messages, isLoggedIn) => {
-    const state = get();
-    // Guard: skip save during session transition to prevent message contamination
-    if (state.isTransitioning) {
-      console.log('[ChatStore] Skipping save — session transition in progress');
-      return;
-    }
-    let storageKey: string;
-    let userId: string | null = null;
+  saveChatSession: (type, messages, isLoggedIn) => {
+    // BUG-3 fix: Promise 체이닝으로 save를 직렬화
+    saveQueue = saveQueue.then(async () => {
+      const state = get();
+      // Guard: skip save during session transition to prevent message contamination
+      if (state.isTransitioning) {
+        return;
+      }
+      let storageKey: string;
+      let userId: string | null = null;
 
-    console.log('[ChatStore] saveChatSession called:', {
-      type,
-      messageCount: messages.length,
-      backendSessionId: state.backendSessionId,
-      currentSessionId: state.currentSessionId,
-    });
+      if (isLoggedIn) {
+        userId = getCurrentUserId();
+        storageKey = getUserChatSessionsKey(userId);
+      } else {
+        storageKey = STORAGE_KEYS.TEMP_CHAT_SESSIONS;
+      }
 
-    if (isLoggedIn) {
-      // 로그인 사용자: 사용자별 고유 key 사용
-      userId = getCurrentUserId();
-      storageKey = getUserChatSessionsKey(userId);
-    } else {
-      // 비로그인 사용자: 임시 세션 key 사용
-      storageKey = STORAGE_KEYS.TEMP_CHAT_SESSIONS;
-    }
+      let sessions = storage.get<ChatSession[]>(storageKey, !isLoggedIn) || [];
 
-    let sessions = storage.get<ChatSession[]>(storageKey, !isLoggedIn) || [];
+      // 세션 ID 결정 우선순위:
+      // 1. backendSessionId (백엔드에서 반환한 ID - 가장 우선)
+      // 2. currentSessionId (프론트엔드 로컬 ID)
+      // 3. 새 ID 생성
+      let newSessionId = state.backendSessionId || state.currentSessionId;
 
-    // 세션 ID 결정 우선순위:
-    // 1. backendSessionId (백엔드에서 반환한 ID - 가장 우선)
-    // 2. currentSessionId (프론트엔드 로컬 ID)
-    // 3. 새 ID 생성
-    let newSessionId = state.backendSessionId || state.currentSessionId;
-
-    // 백엔드 session_id를 받았고, 기존 currentSessionId와 다른 경우
-    // 임시 ID로 저장된 세션을 백엔드 ID로 변경
-    if (state.backendSessionId && state.currentSessionId &&
-        state.backendSessionId !== state.currentSessionId) {
-
-      // 이미 백엔드 ID를 가진 세션이 있는지 확인 (중복 방지)
-      const backendSessionExists = sessions.some((s) => s.id === state.backendSessionId);
-
-      if (!backendSessionExists) {
-        const oldSessionIndex = sessions.findIndex((s) => s.id === state.currentSessionId);
-        if (oldSessionIndex >= 0) {
-          // 임시 ID 세션을 백엔드 ID로 변경
-          sessions[oldSessionIndex].id = state.backendSessionId;
-          console.log(`[ChatStore] Updated session ID: ${state.currentSessionId} -> ${state.backendSessionId}`);
+      // 백엔드 session_id를 받았고, 기존 currentSessionId와 다른 경우
+      // 임시 ID로 저장된 세션을 백엔드 ID로 변경
+      if (state.backendSessionId && state.currentSessionId &&
+          state.backendSessionId !== state.currentSessionId) {
+        const backendSessionExists = sessions.some((s) => s.id === state.backendSessionId);
+        if (!backendSessionExists) {
+          const oldSessionIndex = sessions.findIndex((s) => s.id === state.currentSessionId);
+          if (oldSessionIndex >= 0) {
+            sessions[oldSessionIndex].id = state.backendSessionId;
+          }
         }
       }
-    }
 
-    if (!isLoggedIn) {
-      // 비로그인 사용자는 최대 1개의 세션만 유지
-      if (sessions.length > 0 && !newSessionId) {
-        // 기존 세션이 있으면 재사용
-        newSessionId = sessions[0].id;
-      } else if (!newSessionId) {
-        // 새 게스트 세션 ID 생성
-        newSessionId = await generateGuestSessionId();
-      }
-      // 기존 세션 모두 삭제 (최대 1개만 유지)
-      sessions = sessions.filter((s) => s.id === newSessionId);
-    } else {
-      // 로그인 사용자: ID가 없으면 새로 생성 (단, 중복 방지)
-      if (!newSessionId) {
-        newSessionId = Date.now().toString();
-        console.log(`[ChatStore] Generated new session ID: ${newSessionId}`);
+      if (!isLoggedIn) {
+        if (sessions.length > 0 && !newSessionId) {
+          newSessionId = sessions[0].id;
+        } else if (!newSessionId) {
+          newSessionId = await generateGuestSessionId();
+        }
+        sessions = sessions.filter((s) => s.id === newSessionId);
       } else {
-        console.log(`[ChatStore] Using existing session ID: ${newSessionId}`);
+        if (!newSessionId) {
+          newSessionId = Date.now().toString();
+        }
       }
-    }
 
-    // Title 생성
-    const title = generateTitleFromMessages(type, messages);
+      const title = generateTitleFromMessages(type, messages);
 
-    // 중복 세션 제거: 같은 ID를 가진 세션이 여러 개 있으면 하나만 남김
-    const uniqueSessions: ChatSession[] = [];
-    const seenIds = new Set<string>();
-    for (const session of sessions) {
-      if (!seenIds.has(session.id)) {
-        uniqueSessions.push(session);
-        seenIds.add(session.id);
+      // 중복 세션 제거
+      const uniqueSessions: ChatSession[] = [];
+      const seenIds = new Set<string>();
+      for (const session of sessions) {
+        if (!seenIds.has(session.id)) {
+          uniqueSessions.push(session);
+          seenIds.add(session.id);
+        }
       }
-    }
-    sessions = uniqueSessions;
+      sessions = uniqueSessions;
 
-    const sessionIndex = sessions.findIndex((s) => s.id === newSessionId);
-    const now = Date.now();
-    const expiresAt = !isLoggedIn ? now + SESSION_EXPIRY_DURATION : null;
+      const sessionIndex = sessions.findIndex((s) => s.id === newSessionId);
+      const now = Date.now();
+      const expiresAt = !isLoggedIn ? now + SESSION_EXPIRY_DURATION : null;
 
-    const sessionData: ChatSession = {
-      id: newSessionId,
-      type,
-      title,
-      createdAt: sessionIndex >= 0 ? sessions[sessionIndex].createdAt : now,
-      lastMessageAt: new Date(),
-      expiresAt:
-        sessionIndex >= 0 ? sessions[sessionIndex].expiresAt : expiresAt,
-      lastUpdated: now,
-      messages: messages.map((msg) => ({
-        ...msg,
-        timestamp: msg.timestamp instanceof Date ? msg.timestamp : new Date(msg.timestamp),
-      })),
-    };
+      const sessionData: ChatSession = {
+        id: newSessionId,
+        type,
+        title,
+        createdAt: sessionIndex >= 0 ? sessions[sessionIndex].createdAt : now,
+        lastMessageAt: new Date(),
+        expiresAt:
+          sessionIndex >= 0 ? sessions[sessionIndex].expiresAt : expiresAt,
+        lastUpdated: now,
+        messages: messages.map((msg) => ({
+          ...msg,
+          timestamp: msg.timestamp instanceof Date ? msg.timestamp : new Date(msg.timestamp),
+        })),
+      };
 
-    if (sessionIndex >= 0) {
-      console.log(`[ChatStore] Updating existing session at index ${sessionIndex}`);
-      sessions[sessionIndex] = sessionData;
-    } else {
-      console.log(`[ChatStore] Creating new session`);
-      sessions.unshift(sessionData);
-    }
+      if (sessionIndex >= 0) {
+        sessions[sessionIndex] = sessionData;
+      } else {
+        sessions.unshift(sessionData);
+      }
 
-    storage.set(storageKey, sessions, !isLoggedIn);
+      storage.set(storageKey, sessions, !isLoggedIn);
 
-    // 로그인 사용자의 경우 숨긴 세션 필터링
-    const visibleSessions = isLoggedIn ? filterHiddenSessions(sessions, getCurrentUserId()) : sessions;
-    set({ chatSessions: visibleSessions, currentSessionId: newSessionId });
+      const visibleSessions = isLoggedIn ? filterHiddenSessions(sessions, getCurrentUserId()) : sessions;
+      set({ chatSessions: visibleSessions, currentSessionId: newSessionId });
+    }).catch((err) => {
+      console.error('[ChatStore] saveChatSession error:', err);
+    });
   },
 
   deleteChatSession: async (sessionId, isLoggedIn) => {


### PR DESCRIPTION
## Summary

대화 내역 관련 7개 버그 종합 수정. 세션 전환/저장/복원 전 과정의 안정성을 개선합니다.

- **BUG-1** [CRITICAL]: 세션 전환 시 `backendSessionId` 미초기화 → 메시지가 잘못된 세션에 저장
- **BUG-2** [HIGH]: 유저 메시지 append에서 stale closure → 빠른 연속 전송 시 메시지 소실
- **BUG-3** [HIGH]: localStorage 비원자적 read-modify-write → dispute/general 동시 저장 시 유실
- **BUG-4** [MEDIUM]: 300ms 하드코딩 타이머 → 복원 완료 기반으로 변경
- **BUG-5** [MEDIUM]: 백엔드 DB user 메시지 저장 실패 시 silent → 예외 전파 (500)
- **BUG-6** [LOW]: 스트리밍 취소 시 부분 응답 미저장 → 저장 시도
- **BUG-7** [LOW]: debug console.log 제거

## 변경 파일

| 파일 | 수정 내용 |
|------|----------|
| `ChatPage.tsx` | BUG-1, 2, 4, 7 |
| `chat.store.ts` | BUG-3, 7 |
| `memory.py` | BUG-5 |
| `chat.py` | BUG-6 |

## Test plan

- [ ] 세션 A → B 전환 후 메시지 전송 → B에만 저장 확인
- [ ] 메시지 2~3개 빠르게 연속 전송 → 모두 순서대로 유지
- [ ] dispute + general 거의 동시 저장 → 두 세션 모두 데이터 무결성
- [ ] 스트리밍 중 세션 전환 → 원래 세션에 부분 응답 저장, 새 세션 오염 없음
- [ ] 페이지 새로고침 후 모든 메시지 정상 복원
- [ ] `npm run build` 통과 ✅
- [ ] `ruff check` 통과 ✅

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)