### PR TITLE
fix: 새 채팅 AI 답변 미출력 + 세션 오염 버그 수정 (BUG-8, 9)

### DIFF
--- a/frontend/src/features/chat/ChatPage.tsx
+++ b/frontend/src/features/chat/ChatPage.tsx
@@ -339,7 +339,10 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
 
       // 스트림 응답 후 세션이 전환됐는지 확인 (버퍼에 남은 데이터로 인한 오염 방지)
       // store에서 직접 읽어야 함 - 클로저의 resolvedSessionId는 렌더 시점 값이라 변하지 않음
-      if (isTransitioningRef.current || useChatStore.getState().currentSessionId !== expectedSessionId) {
+      // BUG-8 fix: expectedSessionId가 null(새 채팅)이면 세션 생성으로 인한 ID 변경이므로 가드 스킵
+      const currentStoreSessionId = useChatStore.getState().currentSessionId;
+      if (isTransitioningRef.current ||
+          (expectedSessionId !== null && currentStoreSessionId !== expectedSessionId)) {
         return;
       }
 
@@ -462,7 +465,10 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
 
       // 스트림 응답 후 세션이 전환됐는지 확인 (버퍼에 남은 데이터로 인한 오염 방지)
       // store에서 직접 읽어야 함 - 클로저의 resolvedSessionId는 렌더 시점 값이라 변하지 않음
-      if (isTransitioningRef.current || useChatStore.getState().currentSessionId !== expectedSessionId) {
+      // BUG-8 fix: expectedSessionId가 null(새 채팅)이면 세션 생성으로 인한 ID 변경이므로 가드 스킵
+      const currentStoreSessionId = useChatStore.getState().currentSessionId;
+      if (isTransitioningRef.current ||
+          (expectedSessionId !== null && currentStoreSessionId !== expectedSessionId)) {
         return;
       }
 
@@ -536,7 +542,10 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
 
       // 스트림 응답 후 세션이 전환됐는지 확인 (버퍼에 남은 데이터로 인한 오염 방지)
       // store에서 직접 읽어야 함 - 클로저의 resolvedSessionId는 렌더 시점 값이라 변하지 않음
-      if (isTransitioningRef.current || useChatStore.getState().currentSessionId !== expectedSessionId) {
+      // BUG-8 fix: expectedSessionId가 null(새 채팅)이면 세션 생성으로 인한 ID 변경이므로 가드 스킵
+      const currentStoreSessionId = useChatStore.getState().currentSessionId;
+      if (isTransitioningRef.current ||
+          (expectedSessionId !== null && currentStoreSessionId !== expectedSessionId)) {
         return;
       }
 

--- a/frontend/src/features/chat/hooks/useStreamingChat.ts
+++ b/frontend/src/features/chat/hooks/useStreamingChat.ts
@@ -109,6 +109,9 @@ export function useStreamingChat(options: UseStreamingChatOptions = {}): UseStre
       });
 
       const backendSessionId = useChatStore.getState().backendSessionId;
+      // BUG-9 fix: 스트림 시작 시점의 backendSessionId를 캡처하여
+      // complete 시 세션 전환 여부를 판별
+      const capturedBackendSessionId = backendSessionId;
       const onboarding = request.onboarding || convertDisputeFormToOnboarding();
 
       const enhancedRequest: ChatAPIRequest = {
@@ -179,7 +182,13 @@ export function useStreamingChat(options: UseStreamingChatOptions = {}): UseStre
                   onStatusUpdate?.(status, progress, node);
                 } else if (eventData.type === 'complete') {
                   completeData = eventData.data;
-                  setBackendSessionId(completeData.session_id);
+                  // BUG-9 fix: 세션 전환이 발생하지 않은 경우에만 backendSessionId 업데이트
+                  // 세션 전환 시 backendSessionId가 새 세션 ID로 변경되므로
+                  // capturedBackendSessionId와 다르면 전환된 것
+                  const currentBackendSessionId = useChatStore.getState().backendSessionId;
+                  if (currentBackendSessionId === capturedBackendSessionId) {
+                    setBackendSessionId(completeData.session_id);
+                  }
                   setStreamingState({
                     isStreaming: false,
                     currentNode: null,


### PR DESCRIPTION
## Summary

새 채팅에서 AI 답변이 출력되지 않고, 별도 세션에 대화가 생성되는 버그 수정.

- **BUG-8** [CRITICAL]: 새 채팅 시 `saveChatSession`이 `currentSessionId`를 null→tempId로 변경하면서 세션 전환 가드가 오발동 → AI 응답 폐기. `expectedSessionId`가 null(새 채팅)이면 가드 스킵.
- **BUG-9** [HIGH]: `useStreamingChat`에서 `complete` 이벤트 시 `setBackendSessionId`를 무조건 호출하여 세션 전환 후 오염. 스트림 시작 시점 ID를 캡처하여 전환 판별.

## 변경 파일

| 파일 | 수정 |
|------|------|
| `ChatPage.tsx` | 3곳 세션 전환 가드에 null 체크 추가 |
| `useStreamingChat.ts` | complete 이벤트 시 backendSessionId 변경 여부 확인 |

## Test plan

- [ ] 새 채팅에서 메시지 전송 → AI 답변 정상 출력
- [ ] 기존 세션에서 추가 메시지 → 정상 출력
- [ ] 스트리밍 중 세션 전환 → 새 세션에 오염 없음
- [ ] `npm run build` 통과 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)