### PR TITLE
fix: 대화 내역 세션 간 덮어씌움 근본 원인 수정

### DIFF
--- a/frontend/src/features/chat/ChatPage.tsx
+++ b/frontend/src/features/chat/ChatPage.tsx
@@ -12,6 +12,16 @@ import { MessageBubble } from './components/MessageBubble';
 import { SafetyWarning } from './components/SafetyWarning';
 import { StatusIndicator } from './components/StatusIndicator';
 
+// Fix 2: Initial messages constant for clearing opposite chat type
+const initialGreetingMessages: MessageWithCitations[] = [
+  {
+    id: 1,
+    type: 'ai',
+    content: '안녕하세요! 똑소리 AI 상담입니다. 무엇을 도와드릴까요?',
+    timestamp: new Date()
+  }
+];
+
 interface ChatPageProps {
   currentSessionId?: string | null;
   onSessionCreate?: (sessionId: string) => void;
@@ -30,6 +40,9 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
   const setIsTransitioning = useChatStore((state) => state.setIsTransitioning);
   const isTransitioningRef = useRef(false);
   const resolvedSessionId = currentSessionId ?? storeSessionId;
+
+  // Fix 1: Stream token for validating stream responses belong to current session
+  const streamTokenRef = useRef<string | null>(null);
 
   // Bug 1 fix: Track previous session ID to detect actual session switches
   // undefined = initial mount (never seen a session), null = new chat, string = specific session
@@ -125,6 +138,9 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
     isTransitioningRef.current = true;
     setIsTransitioning(true);
 
+    // Fix 1: Invalidate any in-flight stream token on session change
+    streamTokenRef.current = null;
+
     // Cancel active streams only on actual session switch
     if (isSessionSwitch) {
       cancelDisputeStream();
@@ -162,6 +178,8 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
 
         if (chatType === 'dispute') {
           setDisputeMessages(restoredMessages);
+          // Fix 2: Clear opposite chat type messages to prevent cross-contamination
+          setGeneralMessages([...initialGreetingMessages]);
           setActiveChatType('dispute');
           setIsFormSubmitted(true);
           setStoreChatType('dispute');
@@ -172,6 +190,8 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
           transitionTimersRef.current.push(scrollTimer);
         } else {
           setGeneralMessages(restoredMessages);
+          // Fix 2: Clear opposite chat type messages to prevent cross-contamination
+          setDisputeMessages([...initialGreetingMessages]);
           setActiveChatType('general');
           setStoreChatType('general');
           // Bug 2 fix: Register scroll timer for cleanup
@@ -180,18 +200,23 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
           }, 200);
           transitionTimersRef.current.push(scrollTimer);
         }
-        // BUG-4 fix: 메시지 복원 완료 후 즉시 전환 가드 해제 (300ms 타이머 대신)
-        // 스크롤 타이머는 UX용이므로 유지하되 전환 가드와 분리
-        isTransitioningRef.current = false;
-        setIsTransitioning(false);
+        // Fix 4: Defer guard release to microtask so save useEffects
+        // (which run in the next render cycle) still see isTransitioning=true
+        queueMicrotask(() => {
+          isTransitioningRef.current = false;
+          setIsTransitioning(false);
+        });
       } else if (storeActiveChatType) {
         // 세션이 없지만 store에 chatType이 설정되어 있는 경우
         setActiveChatType(storeActiveChatType);
         if (storeActiveChatType === 'dispute') {
           setIsFormSubmitted(false);
         }
-        isTransitioningRef.current = false;
-        setIsTransitioning(false);
+        // Fix 4: Defer guard release to microtask
+        queueMicrotask(() => {
+          isTransitioningRef.current = false;
+          setIsTransitioning(false);
+        });
       }
     } else {
       setSessionId(null);
@@ -225,8 +250,11 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
         purchaseAmount: '',
         disputeDetail: ''
       });
-      isTransitioningRef.current = false;
-      setIsTransitioning(false);
+      // Fix 4: Defer guard release to microtask
+      queueMicrotask(() => {
+        isTransitioningRef.current = false;
+        setIsTransitioning(false);
+      });
     }
 
     // Bug 2 fix: Cleanup all timers on unmount or next re-trigger
@@ -237,10 +265,10 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [resolvedSessionId, setStoreChatType, setStoreSessionId, storeSessionId, storeActiveChatType]);
 
-  // 채팅 세션 저장 함수 (store 함수를 래핑)
-  const saveChatSession = useCallback(async (type: ChatType, messages: MessageWithCitations[]) => {
-    // store의 saveChatSession만 호출 (store에서 모든 state 관리)
-    await saveChatSessionToStore(type, messages, isLoggedIn);
+  // Fix 3: 채팅 세션 저장 함수 - targetSessionId를 명시적으로 전달하여
+  // save 실행 시점의 state가 아닌 호출 시점의 세션 ID를 사용
+  const saveChatSession = useCallback(async (type: ChatType, messages: MessageWithCitations[], targetSessionId?: string | null) => {
+    await saveChatSessionToStore(type, messages, isLoggedIn, targetSessionId ?? undefined);
   }, [saveChatSessionToStore, isLoggedIn]);
 
   const disputeMessagesEndRef = useRef<HTMLDivElement | null>(null);
@@ -261,7 +289,8 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
     }
     const hasUserMessage = disputeMessages.some(m => m.type === 'user');
     if (disputeMessages.length > 1 && hasUserMessage) {
-      saveChatSession('dispute', disputeMessages);
+      // Fix 3: Pass sessionId explicitly so save uses call-time ID, not execution-time state
+      saveChatSession('dispute', disputeMessages, sessionId);
     }
   }, [disputeMessages, saveChatSession, isTransitioning, sessionId]);
 
@@ -275,7 +304,8 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
     }
     const hasUserMessage = generalMessages.some(m => m.type === 'user');
     if (generalMessages.length > 1 && hasUserMessage) {
-      saveChatSession('general', generalMessages);
+      // Fix 3: Pass sessionId explicitly so save uses call-time ID, not execution-time state
+      saveChatSession('general', generalMessages, sessionId);
     }
   }, [generalMessages, saveChatSession, isTransitioning, sessionId]);
 
@@ -291,8 +321,9 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
       return;
     }
 
-    // 핸들러 진입 시 세션 ID 캡처 (스트림 응답 후 세션 전환 감지용)
-    const expectedSessionId = resolvedSessionId;
+    // Fix 1: Generate unique stream token — session transitions invalidate it
+    const token = crypto.randomUUID();
+    streamTokenRef.current = token;
 
     const formDataForBackend: DisputeFormData = {
       purchaseDate: disputeForm.purchaseDate,
@@ -337,12 +368,8 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
         },
       });
 
-      // 스트림 응답 후 세션이 전환됐는지 확인 (버퍼에 남은 데이터로 인한 오염 방지)
-      // store에서 직접 읽어야 함 - 클로저의 resolvedSessionId는 렌더 시점 값이라 변하지 않음
-      // BUG-8 fix: expectedSessionId가 null(새 채팅)이면 세션 생성으로 인한 ID 변경이므로 가드 스킵
-      const currentStoreSessionId = useChatStore.getState().currentSessionId;
-      if (isTransitioningRef.current ||
-          (expectedSessionId !== null && currentStoreSessionId !== expectedSessionId)) {
+      // Fix 1/6: Stream token guard — if token was invalidated by session transition, discard response
+      if (streamTokenRef.current !== token) {
         return;
       }
 
@@ -436,8 +463,9 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
   const handleDisputeSend = async () => {
     if (!disputeInputValue.trim() || disputeStreamingState.isStreaming) return;
 
-    // 핸들러 진입 시 세션 ID 캡처 (스트림 응답 후 세션 전환 감지용)
-    const expectedSessionId = resolvedSessionId;
+    // Fix 1: Generate unique stream token
+    const token = crypto.randomUUID();
+    streamTokenRef.current = token;
 
     // Phase 2-16: 입력 텍스트 정제 (대화 히스토리 제거)
     const cleanedInput = cleanUserInput(disputeInputValue);
@@ -463,12 +491,8 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
         top_k: 5,
       });
 
-      // 스트림 응답 후 세션이 전환됐는지 확인 (버퍼에 남은 데이터로 인한 오염 방지)
-      // store에서 직접 읽어야 함 - 클로저의 resolvedSessionId는 렌더 시점 값이라 변하지 않음
-      // BUG-8 fix: expectedSessionId가 null(새 채팅)이면 세션 생성으로 인한 ID 변경이므로 가드 스킵
-      const currentStoreSessionId = useChatStore.getState().currentSessionId;
-      if (isTransitioningRef.current ||
-          (expectedSessionId !== null && currentStoreSessionId !== expectedSessionId)) {
+      // Fix 1/6: Stream token guard
+      if (streamTokenRef.current !== token) {
         return;
       }
 
@@ -511,8 +535,9 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
   const handleGeneralSend = async () => {
     if (!generalInputValue.trim() || generalStreamingState.isStreaming) return;
 
-    // 핸들러 진입 시 세션 ID 캡처 (스트림 응답 후 세션 전환 감지용)
-    const expectedSessionId = resolvedSessionId;
+    // Fix 1: Generate unique stream token
+    const token = crypto.randomUUID();
+    streamTokenRef.current = token;
 
     // Phase 2-16: 입력 텍스트 정제 (대화 히스토리 제거)
     const cleanedInput = cleanUserInput(generalInputValue);
@@ -540,12 +565,8 @@ export default function ChatPage({ currentSessionId = null, onSessionCreate }: C
         top_k: 5,
       });
 
-      // 스트림 응답 후 세션이 전환됐는지 확인 (버퍼에 남은 데이터로 인한 오염 방지)
-      // store에서 직접 읽어야 함 - 클로저의 resolvedSessionId는 렌더 시점 값이라 변하지 않음
-      // BUG-8 fix: expectedSessionId가 null(새 채팅)이면 세션 생성으로 인한 ID 변경이므로 가드 스킵
-      const currentStoreSessionId = useChatStore.getState().currentSessionId;
-      if (isTransitioningRef.current ||
-          (expectedSessionId !== null && currentStoreSessionId !== expectedSessionId)) {
+      // Fix 1/6: Stream token guard
+      if (streamTokenRef.current !== token) {
         return;
       }
 

--- a/frontend/src/features/chat/chat.store.ts
+++ b/frontend/src/features/chat/chat.store.ts
@@ -111,7 +111,7 @@ interface ChatState {
   setIsTransitioning: (transitioning: boolean) => void;
 
   loadChatSessions: (isLoggedIn: boolean) => void;
-  saveChatSession: (type: ChatType, messages: MessageWithCitations[], isLoggedIn: boolean) => void;
+  saveChatSession: (type: ChatType, messages: MessageWithCitations[], isLoggedIn: boolean, targetSessionId?: string) => void;
   deleteChatSession: (sessionId: string, isLoggedIn: boolean) => Promise<void>;
   refreshSessionTime: (sessionId: string) => void;
   startNewChat: () => void;
@@ -186,7 +186,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
     set({ chatSessions: sessions });
   },
 
-  saveChatSession: (type, messages, isLoggedIn) => {
+  saveChatSession: (type, messages, isLoggedIn, targetSessionId?) => {
     // BUG-3 fix: Promise 체이닝으로 save를 직렬화
     saveQueue = saveQueue.then(async () => {
       const state = get();
@@ -206,11 +206,12 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
       let sessions = storage.get<ChatSession[]>(storageKey, !isLoggedIn) || [];
 
-      // 세션 ID 결정 우선순위:
-      // 1. backendSessionId (백엔드에서 반환한 ID - 가장 우선)
-      // 2. currentSessionId (프론트엔드 로컬 ID)
-      // 3. 새 ID 생성
-      let newSessionId = state.backendSessionId || state.currentSessionId;
+      // Fix 3: 세션 ID 결정 우선순위:
+      // 1. targetSessionId (호출자가 명시적으로 전달한 ID - 가장 우선)
+      // 2. backendSessionId (백엔드에서 반환한 ID)
+      // 3. currentSessionId (프론트엔드 로컬 ID)
+      // 4. 새 ID 생성
+      let newSessionId = targetSessionId || state.backendSessionId || state.currentSessionId;
 
       // 백엔드 session_id를 받았고, 기존 currentSessionId와 다른 경우
       // 임시 ID로 저장된 세션을 백엔드 ID로 변경

--- a/frontend/src/features/chat/hooks/useStreamingChat.ts
+++ b/frontend/src/features/chat/hooks/useStreamingChat.ts
@@ -182,11 +182,11 @@ export function useStreamingChat(options: UseStreamingChatOptions = {}): UseStre
                   onStatusUpdate?.(status, progress, node);
                 } else if (eventData.type === 'complete') {
                   completeData = eventData.data;
-                  // BUG-9 fix: 세션 전환이 발생하지 않은 경우에만 backendSessionId 업데이트
-                  // 세션 전환 시 backendSessionId가 새 세션 ID로 변경되므로
-                  // capturedBackendSessionId와 다르면 전환된 것
+                  // Fix 5: 세션 전환이 발생하지 않은 경우에만 backendSessionId 업데이트
+                  // capturedBackendSessionId === null은 새 채팅 시작을 의미하므로 항상 업데이트 허용
                   const currentBackendSessionId = useChatStore.getState().backendSessionId;
-                  if (currentBackendSessionId === capturedBackendSessionId) {
+                  if (currentBackendSessionId === capturedBackendSessionId
+                      || capturedBackendSessionId === null) {
                     setBackendSessionId(completeData.session_id);
                   }
                   setStreamingState({


### PR DESCRIPTION
## Summary

- **streamTokenRef 패턴** 도입: `expectedSessionId` null 비교 문제를 해결하여 세션 전환 시 스트림 응답이 잘못된 세션에 추가되는 것을 차단
- **반대쪽 메시지 초기화**: dispute→general 또는 general→dispute 전환 시 반대쪽 메시지를 리셋하여 cross-contamination 방지
- **saveChatSession에 targetSessionId 명시적 전달**: Promise 큐 실행 시점의 state가 아닌 호출 시점의 세션 ID 사용
- **isTransitioningRef를 queueMicrotask로 지연 해제**: save useEffect가 다음 render cycle에서 실행될 때까지 전환 가드 유지
- **capturedBackendSessionId null 허용**: 새 채팅에서 backendSessionId가 올바르게 설정되도록 수정

## Root Cause Analysis

프론트엔드 상태 관리에 5가지 구조적 취약점이 있었음:
1. `isTransitioningRef`가 동기적으로 해제되어 save 가드가 무력화
2. 세션 타입 전환 시 반대쪽 메시지가 잔존하여 save useEffect가 잘못된 세션에 저장
3. `saveChatSession`이 실행 시점의 state를 읽어 세션 전환 후 잘못된 ID 사용
4. BUG-9 fix에서 `null === null` 비교로 새 채팅 시 backendSessionId 업데이트 스킵
5. BUG-8 fix에서 `expectedSessionId === null` 가드 우회

## Changed Files

| 파일 | 변경 | 취약점 |
|------|------|--------|
| `ChatPage.tsx` | streamTokenRef, 반대쪽 초기화, microtask 지연, targetSessionId 전달 | 1,2,4,5 |
| `chat.store.ts` | targetSessionId 파라미터 추가 | 3 |
| `useStreamingChat.ts` | capturedBackendSessionId null 허용 | 4 |

## Test plan

- [ ] 새 채팅 → 메시지 전송 → 응답 정상 수신 (backendSessionId 올바르게 설정)
- [ ] 새 채팅 → 스트리밍 중 세션 전환 → 원래/새 세션 모두 오염 없음
- [ ] 기존 세션 A → 세션 B 전환 → A 메시지가 B에 저장되지 않음
- [ ] dispute → general 세션 전환 → dispute 메시지가 general에 저장되지 않음
- [ ] 빠른 연속 세션 전환 (A→B→A→B) → 모든 세션 데이터 무결성 유지
- [ ] 새 채팅 → 메시지 2개 연속 전송 → 두 번째 메시지가 올바른 backendSessionId로 전송

🤖 Generated with [Claude Code](https://claude.com/claude-code)